### PR TITLE
Fix error handle for clang.FromDirectory()

### DIFF
--- a/cmd/go-clang-compdb/main.go
+++ b/cmd/go-clang-compdb/main.go
@@ -30,7 +30,7 @@ func main() {
 	f.Close()
 
 	err, db := clang.FromDirectory(dir)
-	if err != nil {
+	if err != clang.CompilationDatabase_NoError {
 		fmt.Printf("**error: could not open compilation database at [%s]: %v\n", dir, err)
 
 		os.Exit(1)


### PR DESCRIPTION
Even if the error does not occur, `clang.FromDirectory()` will be return `CompilationDatabase=NoError`.
Not able to handle the error with `nil`.
