### PR TITLE
Upgrade to Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.7.1
 
 addons:
   apt:
@@ -13,14 +13,20 @@ addons:
       - libclang1-3.4
       - libclang-3.4-dev
 
+env:
+  global:
+    - CC=clang CXX=clang++
+
 install:
   - mkdir -p /home/travis/bin
+  - sudo ln -s /usr/bin/clang-3.4 /home/travis/bin/clang
   - sudo ln -s /usr/bin/llvm-config-3.4 /home/travis/bin/llvm-config
   - sudo ldconfig
 
   - llvm-config --version
   - llvm-config --includedir
   - llvm-config --libdir
+  - clang --version
 
   - make install-dependencies
   - make install-tools
@@ -30,5 +36,4 @@ script:
   - make install
 
   # Test without any coverage
-  - make test-verbose
-
+  - make test-full

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: all install install-dependencies install-tools test test-verbose
+.PHONY: all install install-dependencies install-tools test test-full test-verbose
 
-ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-export ROOT_DIR
+export ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+export CC := clang
+export CXX := clang++
 
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:) # turn arguments into do-nothing targets
@@ -14,7 +16,10 @@ install:
 install-dependencies:
 	go get -u github.com/stretchr/testify/...
 install-tools:
+
 test:
-	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race ./...
+	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s ./...
+test-full:
+	$(ROOT_DIR)/scripts/test-full.sh
 test-verbose:
-	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race -v ./...
+	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -v ./...

--- a/scripts/test-full.sh
+++ b/scripts/test-full.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+LLVM_VERSION=$(clang --version | grep --max-count=1 "clang version" | sed -r 's/^.*clang version ([0-9]+\.[0-9]+).+$/\1/')
+
+# Test with the race detector
+CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -v -race ./...
+
+# Test with the address sanitizer
+# TODO there is maybe a problem within clang https://github.com/go-clang/gen/issues/123
+# if [ $(echo "$LLVM_VERSION>=3.9" | bc -l) -ne 0 ] && [ $(find `llvm-config --libdir` | grep libclang_rt.san-x86_64.a | wc -l) -ne 0 ]; then CGO_LDFLAGS="-L`llvm-config --libdir` -fsanitize=memory" CGO_CPPFLAGS='-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer' go test -timeout 60s -v -msan ./...; fi


### PR DESCRIPTION
- Upgrades to Go 1.7
- Introduces test-throughout to test with the race detector and (new)
  with the address sanitizer if it is supported by the environment
- Cleanup of some scripts

Fixes #113
