### PR TITLE
Finish go-clang-compdb

### DIFF
--- a/cmd/go-clang-compdb/main.go
+++ b/cmd/go-clang-compdb/main.go
@@ -11,13 +11,17 @@ import (
 )
 
 func main() {
-	if len(os.Args) <= 1 {
+	os.Exit(cmd(os.Args[1:]))
+}
+
+func cmd(args []string) int {
+	if len(args) == 0 {
 		fmt.Printf("**error: you need to give a directory containing a 'compile_commands.json' file\n")
 
-		os.Exit(1)
+		return 1
 	}
 
-	dir := os.ExpandEnv(os.Args[1])
+	dir := os.ExpandEnv(args[0])
 	fmt.Printf(":: inspecting [%s]...\n", dir)
 
 	fname := filepath.Join(dir, "compile_commands.json")
@@ -25,7 +29,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("**error: could not open file [%s]: %v\n", fname, err)
 
-		os.Exit(1)
+		return 1
 	}
 	f.Close()
 
@@ -68,4 +72,6 @@ func main() {
 		}
 	}
 	fmt.Printf(":: inspecting [%s]... [done]\n", dir)
+
+	return 0
 }

--- a/cmd/go-clang-compdb/main_test.go
+++ b/cmd/go-clang-compdb/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoClangCompDB(t *testing.T) {
+	for _, path := range []string{
+		"../../testdata",
+	} {
+		assert.Equal(t, 0, cmd([]string{path}))
+	}
+}

--- a/cmd/go-clang-dump/main.go
+++ b/cmd/go-clang-dump/main.go
@@ -16,8 +16,17 @@ import (
 var fname = flag.String("fname", "", "the file to analyze")
 
 func main() {
+	os.Exit(cmd(os.Args[1:]))
+}
+
+func cmd(args []string) int {
 	fmt.Printf(":: go-clang-dump...\n")
-	flag.Parse()
+	if err := flag.CommandLine.Parse(args); err != nil {
+		fmt.Printf("ERROR: %s", err)
+
+		return 1
+	}
+
 	fmt.Printf(":: fname: %s\n", *fname)
 	fmt.Printf(":: args: %v\n", flag.Args())
 
@@ -25,19 +34,19 @@ func main() {
 		flag.Usage()
 		fmt.Printf("please provide a file name to analyze\n")
 
-		os.Exit(1)
+		return 1
 	}
 
 	idx := clang.NewIndex(0, 1)
 	defer idx.Dispose()
 
-	args := []string{}
+	tuArgs := []string{}
 	if len(flag.Args()) > 0 && flag.Args()[0] == "-" {
-		args = make([]string, len(flag.Args()[1:]))
-		copy(args, flag.Args()[1:])
+		tuArgs = make([]string, len(flag.Args()[1:]))
+		copy(tuArgs, flag.Args()[1:])
 	}
 
-	tu := idx.ParseTranslationUnit(*fname, args, nil, 0)
+	tu := idx.ParseTranslationUnit(*fname, tuArgs, nil, 0)
 	defer tu.Dispose()
 
 	fmt.Printf("tu: %s\n", tu.Spelling())
@@ -76,4 +85,6 @@ func main() {
 	}
 
 	fmt.Printf(":: bye.\n")
+
+	return 0
 }

--- a/cmd/go-clang-dump/main_test.go
+++ b/cmd/go-clang-dump/main_test.go
@@ -1,18 +1,15 @@
-package main_test
+package main
 
 import (
-	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGoClangDump(t *testing.T) {
 	for _, fname := range []string{
 		"../../testdata/basicparsing.c",
 	} {
-		cmd := exec.Command("go-clang-dump", "-fname", fname)
-		err := cmd.Run()
-		if err != nil {
-			t.Fatalf("error running go-clang-dump on %q: %v\n", fname, err)
-		}
+		assert.Equal(t, 0, cmd([]string{"-fname", fname}))
 	}
 }


### PR DESCRIPTION
We need to test go-clang-compdb somehow. This adds a simple execution test which just tests if go-clang-compdb compiles and works without any panics.

See https://github.com/go-clang/gen/issues/46
