### PR TITLE
Allow static linking of go-clang using the "static" build tag

### DIFF
--- a/clang/cgoflags.go
+++ b/clang/cgoflags.go
@@ -1,5 +1,4 @@
 package clang
 
-// #cgo LDFLAGS: -lclang
-// #cgo CFLAGS: -I.
+// #cgo CFLAGS: -I${SRCDIR}
 import "C"

--- a/clang/cgoflags_dynamic.go
+++ b/clang/cgoflags_dynamic.go
@@ -1,0 +1,6 @@
+// +build !static
+
+package clang
+
+// #cgo LDFLAGS: -lclang
+import "C"

--- a/clang/cgoflags_static.go
+++ b/clang/cgoflags_static.go
@@ -1,0 +1,5 @@
+// +build static
+
+package clang
+
+import "C"


### PR DESCRIPTION
The dynamic build is the default and still requires a libclang in a library directory.

Fixes go-clang/gen#116
