### PR TITLE
Switch to Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.7.1
+  - 1.7.x
+  - 1.8.x
 
 addons:
   apt:


### PR DESCRIPTION
We are only supporting the two latest major Go releases.

This PR has a partner https://github.com/go-clang/gen/pull/142 both have to pass.