### PR TITLE
Support Go module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,33 @@
 language: go
 go:
-  - 1.7.1
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - master
+
+cache:
+ directories:
+   - $HOME/.cache/go-build
+   - $HOME/gopath/pkg/mod
+
+git:
+ depth: 10
+
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.4
+      - llvm-toolchain-precise-3.5
     packages:
-      - llvm-3.4
-      - clang-3.4
-      - libclang1-3.4
-      - libclang-3.4-dev
+      - llvm-3.5
+      - clang-3.5
+      - libclang1-3.5
+      - libclang-3.5-dev
 
 env:
   global:
@@ -19,9 +35,9 @@ env:
 
 install:
   - mkdir -p /home/travis/bin
-  - sudo ln -s /usr/bin/clang-3.4 /home/travis/bin/clang
-  - sudo ln -s /usr/bin/clang++-3.4 /home/travis/bin/clang++
-  - sudo ln -s /usr/bin/llvm-config-3.4 /home/travis/bin/llvm-config
+  - sudo ln -s /usr/bin/clang-3.5 /home/travis/bin/clang
+  - sudo ln -s /usr/bin/clang++-3.5 /home/travis/bin/clang++
+  - sudo ln -s /usr/bin/llvm-config-3.5 /home/travis/bin/llvm-config
   - sudo ldconfig
 
   - llvm-config --version

--- a/clang/clang-c/doc.go
+++ b/clang/clang-c/doc.go
@@ -1,0 +1,2 @@
+// Package clang_c holds clang binding C header files.
+package clang_c

--- a/clang/doc.go
+++ b/clang/doc.go
@@ -1,2 +1,6 @@
 // package clang provides native bindings for the clang C API.
 package clang
+
+import (
+	_ "github.com/go-clang/bootstrap/clang/clang-c"
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-clang/bootstrap
+
+go 1.13
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Same as https://github.com/go-clang/clang-v3.9/pull/1 and https://github.com/go-clang/clang-v3.9/pull/2, support Go module.