### PR TITLE
Regenerate from LLVM v3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,11 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.5
+      - llvm-toolchain-trusty-3.9
     packages:
-      - llvm-3.5
-      - clang-3.5
-      - libclang1-3.5
-      - libclang-3.5-dev
+      - llvm-3.9
+      - clang-3.9
+      - libclang-3.9-dev
 
 env:
   global:
@@ -35,9 +34,9 @@ env:
 
 install:
   - mkdir -p /home/travis/bin
-  - sudo ln -s /usr/bin/clang-3.5 /home/travis/bin/clang
-  - sudo ln -s /usr/bin/clang++-3.5 /home/travis/bin/clang++
-  - sudo ln -s /usr/bin/llvm-config-3.5 /home/travis/bin/llvm-config
+  - sudo ln -s /usr/bin/clang-3.9 /home/travis/bin/clang
+  - sudo ln -s /usr/bin/clang++-3.9 /home/travis/bin/clang++
+  - sudo ln -s /usr/bin/llvm-config-3.9 /home/travis/bin/llvm-config
   - sudo ldconfig
 
   - llvm-config --version

--- a/clang/callingconv_gen.go
+++ b/clang/callingconv_gen.go
@@ -9,20 +9,23 @@ import "fmt"
 type CallingConv uint32
 
 const (
-	CallingConv_Default      CallingConv = C.CXCallingConv_Default
-	CallingConv_C                        = C.CXCallingConv_C
-	CallingConv_X86StdCall               = C.CXCallingConv_X86StdCall
-	CallingConv_X86FastCall              = C.CXCallingConv_X86FastCall
-	CallingConv_X86ThisCall              = C.CXCallingConv_X86ThisCall
-	CallingConv_X86Pascal                = C.CXCallingConv_X86Pascal
-	CallingConv_AAPCS                    = C.CXCallingConv_AAPCS
-	CallingConv_AAPCS_VFP                = C.CXCallingConv_AAPCS_VFP
-	CallingConv_PnaclCall                = C.CXCallingConv_PnaclCall
-	CallingConv_IntelOclBicc             = C.CXCallingConv_IntelOclBicc
-	CallingConv_X86_64Win64              = C.CXCallingConv_X86_64Win64
-	CallingConv_X86_64SysV               = C.CXCallingConv_X86_64SysV
-	CallingConv_Invalid                  = C.CXCallingConv_Invalid
-	CallingConv_Unexposed                = C.CXCallingConv_Unexposed
+	CallingConv_Default       CallingConv = C.CXCallingConv_Default
+	CallingConv_C                         = C.CXCallingConv_C
+	CallingConv_X86StdCall                = C.CXCallingConv_X86StdCall
+	CallingConv_X86FastCall               = C.CXCallingConv_X86FastCall
+	CallingConv_X86ThisCall               = C.CXCallingConv_X86ThisCall
+	CallingConv_X86Pascal                 = C.CXCallingConv_X86Pascal
+	CallingConv_AAPCS                     = C.CXCallingConv_AAPCS
+	CallingConv_AAPCS_VFP                 = C.CXCallingConv_AAPCS_VFP
+	CallingConv_IntelOclBicc              = C.CXCallingConv_IntelOclBicc
+	CallingConv_X86_64Win64               = C.CXCallingConv_X86_64Win64
+	CallingConv_X86_64SysV                = C.CXCallingConv_X86_64SysV
+	CallingConv_X86VectorCall             = C.CXCallingConv_X86VectorCall
+	CallingConv_Swift                     = C.CXCallingConv_Swift
+	CallingConv_PreserveMost              = C.CXCallingConv_PreserveMost
+	CallingConv_PreserveAll               = C.CXCallingConv_PreserveAll
+	CallingConv_Invalid                   = C.CXCallingConv_Invalid
+	CallingConv_Unexposed                 = C.CXCallingConv_Unexposed
 )
 
 func (cc CallingConv) Spelling() string {
@@ -43,14 +46,20 @@ func (cc CallingConv) Spelling() string {
 		return "CallingConv=AAPCS"
 	case CallingConv_AAPCS_VFP:
 		return "CallingConv=AAPCS_VFP"
-	case CallingConv_PnaclCall:
-		return "CallingConv=PnaclCall"
 	case CallingConv_IntelOclBicc:
 		return "CallingConv=IntelOclBicc"
 	case CallingConv_X86_64Win64:
 		return "CallingConv=X86_64Win64"
 	case CallingConv_X86_64SysV:
 		return "CallingConv=X86_64SysV"
+	case CallingConv_X86VectorCall:
+		return "CallingConv=X86VectorCall"
+	case CallingConv_Swift:
+		return "CallingConv=Swift"
+	case CallingConv_PreserveMost:
+		return "CallingConv=PreserveMost"
+	case CallingConv_PreserveAll:
+		return "CallingConv=PreserveAll"
 	case CallingConv_Invalid:
 		return "CallingConv=Invalid"
 	case CallingConv_Unexposed:

--- a/clang/clang-c/BuildSystem.h
+++ b/clang/clang-c/BuildSystem.h
@@ -1,0 +1,158 @@
+#include <stdint.h>
+
+/*==-- clang-c/BuildSystem.h - Utilities for use by build systems -*- C -*-===*\
+|*                                                                            *|
+|*                     The LLVM Compiler Infrastructure                       *|
+|*                                                                            *|
+|* This file is distributed under the University of Illinois Open Source      *|
+|* License. See LICENSE.TXT for details.                                      *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides various utilities for use by build systems.           *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_BUILDSYSTEM_H
+#define LLVM_CLANG_C_BUILDSYSTEM_H
+
+#include "clang-c/Platform.h"
+#include "clang-c/CXErrorCode.h"
+#include "clang-c/CXString.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \defgroup BUILD_SYSTEM Build system utilities
+ * @{
+ */
+
+/**
+ * \brief Return the timestamp for use with Clang's
+ * \c -fbuild-session-timestamp= option.
+ */
+CINDEX_LINKAGE unsigned long long clang_getBuildSessionTimestamp(void);
+
+/**
+ * \brief Object encapsulating information about overlaying virtual
+ * file/directories over the real file system.
+ */
+typedef struct CXVirtualFileOverlayImpl *CXVirtualFileOverlay;
+
+/**
+ * \brief Create a \c CXVirtualFileOverlay object.
+ * Must be disposed with \c clang_VirtualFileOverlay_dispose().
+ *
+ * \param options is reserved, always pass 0.
+ */
+CINDEX_LINKAGE CXVirtualFileOverlay
+clang_VirtualFileOverlay_create(unsigned options);
+
+/**
+ * \brief Map an absolute virtual file path to an absolute real one.
+ * The virtual path must be canonicalized (not contain "."/"..").
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_addFileMapping(CXVirtualFileOverlay,
+                                        const char *virtualPath,
+                                        const char *realPath);
+
+/**
+ * \brief Set the case sensitivity for the \c CXVirtualFileOverlay object.
+ * The \c CXVirtualFileOverlay object is case-sensitive by default, this
+ * option can be used to override the default.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_setCaseSensitivity(CXVirtualFileOverlay,
+											int caseSensitive);
+
+/**
+ * \brief Write out the \c CXVirtualFileOverlay object to a char buffer.
+ *
+ * \param options is reserved, always pass 0.
+ * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+ * disposed using \c clang_free().
+ * \param out_buffer_size pointer to receive the buffer size.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_writeToBuffer(CXVirtualFileOverlay, unsigned options,
+                                       char **out_buffer_ptr,
+                                       unsigned *out_buffer_size);
+
+/**
+ * \brief free memory allocated by libclang, such as the buffer returned by
+ * \c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
+ *
+ * \param buffer memory pointer to free.
+ */
+CINDEX_LINKAGE void clang_free(void *buffer);
+
+/**
+ * \brief Dispose a \c CXVirtualFileOverlay object.
+ */
+CINDEX_LINKAGE void clang_VirtualFileOverlay_dispose(CXVirtualFileOverlay);
+
+/**
+ * \brief Object encapsulating information about a module.map file.
+ */
+typedef struct CXModuleMapDescriptorImpl *CXModuleMapDescriptor;
+
+/**
+ * \brief Create a \c CXModuleMapDescriptor object.
+ * Must be disposed with \c clang_ModuleMapDescriptor_dispose().
+ *
+ * \param options is reserved, always pass 0.
+ */
+CINDEX_LINKAGE CXModuleMapDescriptor
+clang_ModuleMapDescriptor_create(unsigned options);
+
+/**
+ * \brief Sets the framework module name that the module.map describes.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_setFrameworkModuleName(CXModuleMapDescriptor,
+                                                 const char *name);
+
+/**
+ * \brief Sets the umbrealla header name that the module.map describes.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_setUmbrellaHeader(CXModuleMapDescriptor,
+                                            const char *name);
+
+/**
+ * \brief Write out the \c CXModuleMapDescriptor object to a char buffer.
+ *
+ * \param options is reserved, always pass 0.
+ * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+ * disposed using \c clang_free().
+ * \param out_buffer_size pointer to receive the buffer size.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_writeToBuffer(CXModuleMapDescriptor, unsigned options,
+                                       char **out_buffer_ptr,
+                                       unsigned *out_buffer_size);
+
+/**
+ * \brief Dispose a \c CXModuleMapDescriptor object.
+ */
+CINDEX_LINKAGE void clang_ModuleMapDescriptor_dispose(CXModuleMapDescriptor);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CLANG_C_BUILD_SYSTEM_H */
+

--- a/clang/clang-c/CXCompilationDatabase.h
+++ b/clang/clang-c/CXCompilationDatabase.h
@@ -14,8 +14,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_CXCOMPILATIONDATABASE_H
-#define CLANG_CXCOMPILATIONDATABASE_H
+#ifndef LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
+#define LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
 
 #include "clang-c/Platform.h"
 #include "clang-c/CXString.h"
@@ -126,6 +126,12 @@ clang_CompileCommands_getCommand(CXCompileCommands, unsigned I);
  */
 CINDEX_LINKAGE CXString
 clang_CompileCommand_getDirectory(CXCompileCommand);
+
+/**
+ * \brief Get the filename associated with the CompileCommand.
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getFilename(CXCompileCommand);
 
 /**
  * \brief Get the number of arguments in the compiler invocation.

--- a/clang/clang-c/CXErrorCode.h
+++ b/clang/clang-c/CXErrorCode.h
@@ -1,0 +1,66 @@
+#include <stdint.h>
+
+/*===-- clang-c/CXErrorCode.h - C Index Error Codes  --------------*- C -*-===*\
+|*                                                                            *|
+|*                     The LLVM Compiler Infrastructure                       *|
+|*                                                                            *|
+|* This file is distributed under the University of Illinois Open Source      *|
+|* License. See LICENSE.TXT for details.                                      *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the CXErrorCode enumerators.                          *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXERRORCODE_H
+#define LLVM_CLANG_C_CXERRORCODE_H
+
+#include "clang-c/Platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Error codes returned by libclang routines.
+ *
+ * Zero (\c CXError_Success) is the only error code indicating success.  Other
+ * error codes, including not yet assigned non-zero values, indicate errors.
+ */
+enum CXErrorCode {
+  /**
+   * \brief No error.
+   */
+  CXError_Success = 0,
+
+  /**
+   * \brief A generic error code, no further details are available.
+   *
+   * Errors of this kind can get their own specific error codes in future
+   * libclang versions.
+   */
+  CXError_Failure = 1,
+
+  /**
+   * \brief libclang crashed while performing the requested operation.
+   */
+  CXError_Crashed = 2,
+
+  /**
+   * \brief The function detected that the arguments violate the function
+   * contract.
+   */
+  CXError_InvalidArguments = 3,
+
+  /**
+   * \brief An AST deserialization error has occurred.
+   */
+  CXError_ASTReadError = 4
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/clang/clang-c/CXString.h
+++ b/clang/clang-c/CXString.h
@@ -13,8 +13,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_CXSTRING_H
-#define CLANG_CXSTRING_H
+#ifndef LLVM_CLANG_C_CXSTRING_H
+#define LLVM_CLANG_C_CXSTRING_H
 
 #include "clang-c/Platform.h"
 
@@ -33,7 +33,7 @@ extern "C" {
  * \brief A character string.
  *
  * The \c CXString type is used to return strings from the interface when
- * the ownership of that string might different from one call to the next.
+ * the ownership of that string might differ from one call to the next.
  * Use \c clang_getCString() to retrieve the string data and, once finished
  * with the string data, call \c clang_disposeString() to free the string.
  */
@@ -41,6 +41,11 @@ typedef struct {
   uintptr_t data;
   unsigned private_flags;
 } CXString;
+
+typedef struct {
+  CXString *Strings;
+  unsigned Count;
+} CXStringSet;
 
 /**
  * \brief Retrieve the character data associated with the given string.
@@ -51,6 +56,11 @@ CINDEX_LINKAGE const char *clang_getCString(CXString string);
  * \brief Free the given string.
  */
 CINDEX_LINKAGE void clang_disposeString(CXString string);
+
+/**
+ * \brief Free the given string set.
+ */
+CINDEX_LINKAGE void clang_disposeStringSet(CXStringSet *set);
 
 /**
  * @}

--- a/clang/clang-c/Documentation.h
+++ b/clang/clang-c/Documentation.h
@@ -1,0 +1,556 @@
+#include <stdint.h>
+
+/*==-- clang-c/Documentation.h - Utilities for comment processing -*- C -*-===*\
+|*                                                                            *|
+|*                     The LLVM Compiler Infrastructure                       *|
+|*                                                                            *|
+|* This file is distributed under the University of Illinois Open Source      *|
+|* License. See LICENSE.TXT for details.                                      *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides a supplementary interface for inspecting              *|
+|* documentation comments.                                                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_DOCUMENTATION_H
+#define LLVM_CLANG_C_DOCUMENTATION_H
+
+#include "clang-c/Index.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \defgroup CINDEX_COMMENT Comment introspection
+ *
+ * The routines in this group provide access to information in documentation
+ * comments. These facilities are distinct from the core and may be subject to
+ * their own schedule of stability and deprecation.
+ *
+ * @{
+ */
+
+/**
+ * \brief A parsed comment.
+ */
+typedef struct {
+  uintptr_t ASTNode;
+  CXTranslationUnit TranslationUnit;
+} CXComment;
+
+/**
+ * \brief Given a cursor that represents a documentable entity (e.g.,
+ * declaration), return the associated parsed comment as a
+ * \c CXComment_FullComment AST node.
+ */
+CINDEX_LINKAGE CXComment clang_Cursor_getParsedComment(CXCursor C);
+
+/**
+ * \brief Describes the type of the comment AST node (\c CXComment).  A comment
+ * node can be considered block content (e. g., paragraph), inline content
+ * (plain text) or neither (the root AST node).
+ */
+enum CXCommentKind {
+  /**
+   * \brief Null comment.  No AST node is constructed at the requested location
+   * because there is no text or a syntax error.
+   */
+  CXComment_Null = 0,
+
+  /**
+   * \brief Plain text.  Inline content.
+   */
+  CXComment_Text = 1,
+
+  /**
+   * \brief A command with word-like arguments that is considered inline content.
+   *
+   * For example: \\c command.
+   */
+  CXComment_InlineCommand = 2,
+
+  /**
+   * \brief HTML start tag with attributes (name-value pairs).  Considered
+   * inline content.
+   *
+   * For example:
+   * \verbatim
+   * <br> <br /> <a href="http://example.org/">
+   * \endverbatim
+   */
+  CXComment_HTMLStartTag = 3,
+
+  /**
+   * \brief HTML end tag.  Considered inline content.
+   *
+   * For example:
+   * \verbatim
+   * </a>
+   * \endverbatim
+   */
+  CXComment_HTMLEndTag = 4,
+
+  /**
+   * \brief A paragraph, contains inline comment.  The paragraph itself is
+   * block content.
+   */
+  CXComment_Paragraph = 5,
+
+  /**
+   * \brief A command that has zero or more word-like arguments (number of
+   * word-like arguments depends on command name) and a paragraph as an
+   * argument.  Block command is block content.
+   *
+   * Paragraph argument is also a child of the block command.
+   *
+   * For example: \\brief has 0 word-like arguments and a paragraph argument.
+   *
+   * AST nodes of special kinds that parser knows about (e. g., \\param
+   * command) have their own node kinds.
+   */
+  CXComment_BlockCommand = 6,
+
+  /**
+   * \brief A \\param or \\arg command that describes the function parameter
+   * (name, passing direction, description).
+   *
+   * For example: \\param [in] ParamName description.
+   */
+  CXComment_ParamCommand = 7,
+
+  /**
+   * \brief A \\tparam command that describes a template parameter (name and
+   * description).
+   *
+   * For example: \\tparam T description.
+   */
+  CXComment_TParamCommand = 8,
+
+  /**
+   * \brief A verbatim block command (e. g., preformatted code).  Verbatim
+   * block has an opening and a closing command and contains multiple lines of
+   * text (\c CXComment_VerbatimBlockLine child nodes).
+   *
+   * For example:
+   * \\verbatim
+   * aaa
+   * \\endverbatim
+   */
+  CXComment_VerbatimBlockCommand = 9,
+
+  /**
+   * \brief A line of text that is contained within a
+   * CXComment_VerbatimBlockCommand node.
+   */
+  CXComment_VerbatimBlockLine = 10,
+
+  /**
+   * \brief A verbatim line command.  Verbatim line has an opening command,
+   * a single line of text (up to the newline after the opening command) and
+   * has no closing command.
+   */
+  CXComment_VerbatimLine = 11,
+
+  /**
+   * \brief A full comment attached to a declaration, contains block content.
+   */
+  CXComment_FullComment = 12
+};
+
+/**
+ * \brief The most appropriate rendering mode for an inline command, chosen on
+ * command semantics in Doxygen.
+ */
+enum CXCommentInlineCommandRenderKind {
+  /**
+   * \brief Command argument should be rendered in a normal font.
+   */
+  CXCommentInlineCommandRenderKind_Normal,
+
+  /**
+   * \brief Command argument should be rendered in a bold font.
+   */
+  CXCommentInlineCommandRenderKind_Bold,
+
+  /**
+   * \brief Command argument should be rendered in a monospaced font.
+   */
+  CXCommentInlineCommandRenderKind_Monospaced,
+
+  /**
+   * \brief Command argument should be rendered emphasized (typically italic
+   * font).
+   */
+  CXCommentInlineCommandRenderKind_Emphasized
+};
+
+/**
+ * \brief Describes parameter passing direction for \\param or \\arg command.
+ */
+enum CXCommentParamPassDirection {
+  /**
+   * \brief The parameter is an input parameter.
+   */
+  CXCommentParamPassDirection_In,
+
+  /**
+   * \brief The parameter is an output parameter.
+   */
+  CXCommentParamPassDirection_Out,
+
+  /**
+   * \brief The parameter is an input and output parameter.
+   */
+  CXCommentParamPassDirection_InOut
+};
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \returns the type of the AST node.
+ */
+CINDEX_LINKAGE enum CXCommentKind clang_Comment_getKind(CXComment Comment);
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \returns number of children of the AST node.
+ */
+CINDEX_LINKAGE unsigned clang_Comment_getNumChildren(CXComment Comment);
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \param ChildIdx child index (zero-based).
+ *
+ * \returns the specified child of the AST node.
+ */
+CINDEX_LINKAGE
+CXComment clang_Comment_getChild(CXComment Comment, unsigned ChildIdx);
+
+/**
+ * \brief A \c CXComment_Paragraph node is considered whitespace if it contains
+ * only \c CXComment_Text nodes that are empty or whitespace.
+ *
+ * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
+ * never considered whitespace.
+ *
+ * \returns non-zero if \c Comment is whitespace.
+ */
+CINDEX_LINKAGE unsigned clang_Comment_isWhitespace(CXComment Comment);
+
+/**
+ * \returns non-zero if \c Comment is inline content and has a newline
+ * immediately following it in the comment text.  Newlines between paragraphs
+ * do not count.
+ */
+CINDEX_LINKAGE
+unsigned clang_InlineContentComment_hasTrailingNewline(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_Text AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE CXString clang_TextComment_getText(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns name of the inline command.
+ */
+CINDEX_LINKAGE
+CXString clang_InlineCommandComment_getCommandName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns the most appropriate rendering mode, chosen on command
+ * semantics in Doxygen.
+ */
+CINDEX_LINKAGE enum CXCommentInlineCommandRenderKind
+clang_InlineCommandComment_getRenderKind(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns number of command arguments.
+ */
+CINDEX_LINKAGE
+unsigned clang_InlineCommandComment_getNumArgs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \param ArgIdx argument index (zero-based).
+ *
+ * \returns text of the specified argument.
+ */
+CINDEX_LINKAGE
+CXString clang_InlineCommandComment_getArgText(CXComment Comment,
+                                               unsigned ArgIdx);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+ * node.
+ *
+ * \returns HTML tag name.
+ */
+CINDEX_LINKAGE CXString clang_HTMLTagComment_getTagName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
+ */
+CINDEX_LINKAGE
+unsigned clang_HTMLStartTagComment_isSelfClosing(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \returns number of attributes (name-value pairs) attached to the start tag.
+ */
+CINDEX_LINKAGE unsigned clang_HTMLStartTag_getNumAttrs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \param AttrIdx attribute index (zero-based).
+ *
+ * \returns name of the specified attribute.
+ */
+CINDEX_LINKAGE
+CXString clang_HTMLStartTag_getAttrName(CXComment Comment, unsigned AttrIdx);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \param AttrIdx attribute index (zero-based).
+ *
+ * \returns value of the specified attribute.
+ */
+CINDEX_LINKAGE
+CXString clang_HTMLStartTag_getAttrValue(CXComment Comment, unsigned AttrIdx);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \returns name of the block command.
+ */
+CINDEX_LINKAGE
+CXString clang_BlockCommandComment_getCommandName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \returns number of word-like arguments.
+ */
+CINDEX_LINKAGE
+unsigned clang_BlockCommandComment_getNumArgs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \param ArgIdx argument index (zero-based).
+ *
+ * \returns text of the specified word-like argument.
+ */
+CINDEX_LINKAGE
+CXString clang_BlockCommandComment_getArgText(CXComment Comment,
+                                              unsigned ArgIdx);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand or
+ * \c CXComment_VerbatimBlockCommand AST node.
+ *
+ * \returns paragraph argument of the block command.
+ */
+CINDEX_LINKAGE
+CXComment clang_BlockCommandComment_getParagraph(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns parameter name.
+ */
+CINDEX_LINKAGE
+CXString clang_ParamCommandComment_getParamName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns non-zero if the parameter that this AST node represents was found
+ * in the function prototype and \c clang_ParamCommandComment_getParamIndex
+ * function will return a meaningful value.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_isParamIndexValid(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns zero-based parameter index in function prototype.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_getParamIndex(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns non-zero if parameter passing direction was specified explicitly in
+ * the comment.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_isDirectionExplicit(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns parameter passing direction.
+ */
+CINDEX_LINKAGE
+enum CXCommentParamPassDirection clang_ParamCommandComment_getDirection(
+                                                            CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns template parameter name.
+ */
+CINDEX_LINKAGE
+CXString clang_TParamCommandComment_getParamName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns non-zero if the parameter that this AST node represents was found
+ * in the template parameter list and
+ * \c clang_TParamCommandComment_getDepth and
+ * \c clang_TParamCommandComment_getIndex functions will return a meaningful
+ * value.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_isParamPositionValid(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns zero-based nesting depth of this parameter in the template parameter list.
+ *
+ * For example,
+ * \verbatim
+ *     template<typename C, template<typename T> class TT>
+ *     void test(TT<int> aaa);
+ * \endverbatim
+ * for C and TT nesting depth is 0,
+ * for T nesting depth is 1.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_getDepth(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns zero-based parameter index in the template parameter list at a
+ * given nesting depth.
+ *
+ * For example,
+ * \verbatim
+ *     template<typename C, template<typename T> class TT>
+ *     void test(TT<int> aaa);
+ * \endverbatim
+ * for C and TT nesting depth is 0, so we can ask for index at depth 0:
+ * at depth 0 C's index is 0, TT's index is 1.
+ *
+ * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
+ * at depth 0 T's index is 1 (same as TT's),
+ * at depth 1 T's index is 0.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_getIndex(CXComment Comment, unsigned Depth);
+
+/**
+ * \param Comment a \c CXComment_VerbatimBlockLine AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE
+CXString clang_VerbatimBlockLineComment_getText(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_VerbatimLine AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE CXString clang_VerbatimLineComment_getText(CXComment Comment);
+
+/**
+ * \brief Convert an HTML tag AST node to string.
+ *
+ * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+ * node.
+ *
+ * \returns string containing an HTML tag.
+ */
+CINDEX_LINKAGE CXString clang_HTMLTagComment_getAsString(CXComment Comment);
+
+/**
+ * \brief Convert a given full parsed comment to an HTML fragment.
+ *
+ * Specific details of HTML layout are subject to change.  Don't try to parse
+ * this HTML back into an AST, use other APIs instead.
+ *
+ * Currently the following CSS classes are used:
+ * \li "para-brief" for \\brief paragraph and equivalent commands;
+ * \li "para-returns" for \\returns paragraph and equivalent commands;
+ * \li "word-returns" for the "Returns" word in \\returns paragraph.
+ *
+ * Function argument documentation is rendered as a \<dl\> list with arguments
+ * sorted in function prototype order.  CSS classes used:
+ * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
+ * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
+ * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
+ * parameter index is invalid.
+ *
+ * Template parameter documentation is rendered as a \<dl\> list with
+ * parameters sorted in template parameter list order.  CSS classes used:
+ * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
+ * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
+ * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
+ * names inside template template parameters;
+ * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
+ * parameter position is invalid.
+ *
+ * \param Comment a \c CXComment_FullComment AST node.
+ *
+ * \returns string containing an HTML fragment.
+ */
+CINDEX_LINKAGE CXString clang_FullComment_getAsHTML(CXComment Comment);
+
+/**
+ * \brief Convert a given full parsed comment to an XML document.
+ *
+ * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
+ * inside clang source tree.
+ *
+ * \param Comment a \c CXComment_FullComment AST node.
+ *
+ * \returns string containing an XML document.
+ */
+CINDEX_LINKAGE CXString clang_FullComment_getAsXML(CXComment Comment);
+
+/**
+ * @}
+ */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CLANG_C_DOCUMENTATION_H */
+

--- a/clang/clang-c/Index.h
+++ b/clang/clang-c/Index.h
@@ -15,13 +15,15 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_C_INDEX_H
-#define CLANG_C_INDEX_H
+#ifndef LLVM_CLANG_C_INDEX_H
+#define LLVM_CLANG_C_INDEX_H
 
 #include <time.h>
 
 #include "clang-c/Platform.h"
+#include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
+#include "clang-c/BuildSystem.h"
 
 /**
  * \brief The version constants for the libclang API.
@@ -32,7 +34,7 @@
  * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
  */
 #define CINDEX_VERSION_MAJOR 0
-#define CINDEX_VERSION_MINOR 20
+#define CINDEX_VERSION_MINOR 35
 
 #define CINDEX_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                       \
@@ -285,7 +287,6 @@ CINDEX_LINKAGE unsigned clang_CXIndex_getGlobalOptions(CXIndex);
  */
 typedef void *CXFile;
 
-
 /**
  * \brief Retrieve the complete file and path name of the given file.
  */
@@ -327,13 +328,19 @@ clang_isFileMultipleIncludeGuarded(CXTranslationUnit tu, CXFile file);
  *
  * \param tu the translation unit
  *
- * \param file_name the name of the file.
+* \param file_name the name of the file.
  *
  * \returns the file handle for the named file in the translation unit \p tu,
  * or a NULL file handle if the file was not a part of this translation unit.
  */
 CINDEX_LINKAGE CXFile clang_getFile(CXTranslationUnit tu,
                                     const char *file_name);
+
+/**
+ * \brief Returns non-zero if the \c file1 and \c file2 point to the same file,
+ * or they are both NULL.
+ */
+CINDEX_LINKAGE int clang_File_isEqual(CXFile file1, CXFile file2);
 
 /**
  * @}
@@ -601,6 +608,32 @@ CINDEX_LINKAGE CXSourceLocation clang_getRangeStart(CXSourceRange range);
 CINDEX_LINKAGE CXSourceLocation clang_getRangeEnd(CXSourceRange range);
 
 /**
+ * \brief Identifies an array of ranges.
+ */
+typedef struct {
+  /** \brief The number of ranges in the \c ranges array. */
+  unsigned count;
+  /**
+   * \brief An array of \c CXSourceRanges.
+   */
+  CXSourceRange *ranges;
+} CXSourceRangeList;
+
+/**
+ * \brief Retrieve all ranges that were skipped by the preprocessor.
+ *
+ * The preprocessor will skip lines when they are surrounded by an
+ * if/ifdef/ifndef directive whose condition does not evaluate to true.
+ */
+CINDEX_LINKAGE CXSourceRangeList *clang_getSkippedRanges(CXTranslationUnit tu,
+                                                         CXFile file);
+
+/**
+ * \brief Destroy the given \c CXSourceRangeList.
+ */
+CINDEX_LINKAGE void clang_disposeSourceRangeList(CXSourceRangeList *ranges);
+
+/**
  * @}
  */
 
@@ -672,7 +705,6 @@ CINDEX_LINKAGE unsigned clang_getNumDiagnosticsInSet(CXDiagnosticSet Diags);
  */
 CINDEX_LINKAGE CXDiagnostic clang_getDiagnosticInSet(CXDiagnosticSet Diags,
                                                      unsigned Index);  
-
 
 /**
  * \brief Describes the kind of error that occurred (if any) in a call to
@@ -1052,10 +1084,27 @@ CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnitFromSourceFile(
                                          struct CXUnsavedFile *unsaved_files);
 
 /**
- * \brief Create a translation unit from an AST file (-emit-ast).
+ * \brief Same as \c clang_createTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
  */
-CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnit(CXIndex,
-                                             const char *ast_filename);
+CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnit(
+    CXIndex CIdx,
+    const char *ast_filename);
+
+/**
+ * \brief Create a translation unit from an AST file (\c -emit-ast).
+ *
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit.
+ *
+ * \returns Zero on success, otherwise returns an error code.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_createTranslationUnit2(
+    CXIndex CIdx,
+    const char *ast_filename,
+    CXTranslationUnit *out_TU);
 
 /**
  * \brief Flags that control the creation of translation units.
@@ -1153,7 +1202,26 @@ enum CXTranslationUnit_Flags {
    * included into the set of code completions returned from this translation
    * unit.
    */
-  CXTranslationUnit_IncludeBriefCommentsInCodeCompletion = 0x80
+  CXTranslationUnit_IncludeBriefCommentsInCodeCompletion = 0x80,
+
+  /**
+   * \brief Used to indicate that the precompiled preamble should be created on
+   * the first parse. Otherwise it will be created on the first reparse. This
+   * trades runtime on the first parse (serializing the preamble takes time) for
+   * reduced runtime on the second parse (can now reuse the preamble).
+   */
+  CXTranslationUnit_CreatePreambleOnFirstParse = 0x100,
+
+  /**
+   * \brief Do not stop processing when fatal errors are encountered.
+   *
+   * When fatal errors are encountered while parsing a translation unit,
+   * semantic analysis is typically stopped early when compiling code. A common
+   * source for fatal errors are unresolvable include files. For the
+   * purposes of an IDE, this is undesirable behavior and as much information
+   * as possible should be reported. Use this flag to enable this behavior.
+   */
+  CXTranslationUnit_KeepGoing = 0x200
 };
 
 /**
@@ -1169,7 +1237,22 @@ enum CXTranslationUnit_Flags {
  * set of optimizations enabled may change from one version to the next.
  */
 CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
-  
+
+/**
+ * \brief Same as \c clang_parseTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
+ */
+CINDEX_LINKAGE CXTranslationUnit
+clang_parseTranslationUnit(CXIndex CIdx,
+                           const char *source_filename,
+                           const char *const *command_line_args,
+                           int num_command_line_args,
+                           struct CXUnsavedFile *unsaved_files,
+                           unsigned num_unsaved_files,
+                           unsigned options);
+
 /**
  * \brief Parse the given source file and the translation unit corresponding
  * to that file.
@@ -1184,7 +1267,7 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * associated.
  *
  * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \p command_line_args.
+ * source file is included in \c command_line_args.
  *
  * \param command_line_args The command-line arguments that would be
  * passed to the \c clang executable if it were being invoked out-of-process.
@@ -1193,7 +1276,7 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
  *
  * \param num_command_line_args The number of command-line arguments in
- * \p command_line_args.
+ * \c command_line_args.
  *
  * \param unsaved_files the files that have not yet been saved to disk
  * but may be required for parsing, including the contents of
@@ -1208,18 +1291,33 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * is managed but not its compilation. This should be a bitwise OR of the
  * CXTranslationUnit_XXX flags.
  *
- * \returns A new translation unit describing the parsed code and containing
- * any diagnostics produced by the compiler. If there is a failure from which
- * the compiler cannot recover, returns NULL.
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit, describing the parsed code and containing any
+ * diagnostics produced by the compiler.
+ *
+ * \returns Zero on success, otherwise returns an error code.
  */
-CINDEX_LINKAGE CXTranslationUnit clang_parseTranslationUnit(CXIndex CIdx,
-                                                    const char *source_filename,
-                                         const char * const *command_line_args,
-                                                      int num_command_line_args,
-                                            struct CXUnsavedFile *unsaved_files,
-                                                     unsigned num_unsaved_files,
-                                                            unsigned options);
-  
+CINDEX_LINKAGE enum CXErrorCode
+clang_parseTranslationUnit2(CXIndex CIdx,
+                            const char *source_filename,
+                            const char *const *command_line_args,
+                            int num_command_line_args,
+                            struct CXUnsavedFile *unsaved_files,
+                            unsigned num_unsaved_files,
+                            unsigned options,
+                            CXTranslationUnit *out_TU);
+
+/**
+ * \brief Same as clang_parseTranslationUnit2 but requires a full command line
+ * for \c command_line_args including argv[0]. This is useful if the standard
+ * library paths are relative to the binary.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_parseTranslationUnit2FullArgv(
+    CXIndex CIdx, const char *source_filename,
+    const char *const *command_line_args, int num_command_line_args,
+    struct CXUnsavedFile *unsaved_files, unsigned num_unsaved_files,
+    unsigned options, CXTranslationUnit *out_TU);
+
 /**
  * \brief Flags that control how translation units are saved.
  *
@@ -1371,10 +1469,11 @@ CINDEX_LINKAGE unsigned clang_defaultReparseOptions(CXTranslationUnit TU);
  * The function \c clang_defaultReparseOptions() produces a default set of
  * options recommended for most uses, based on the translation unit.
  *
- * \returns 0 if the sources could be reparsed. A non-zero value will be
+ * \returns 0 if the sources could be reparsed.  A non-zero error code will be
  * returned if reparsing was impossible, such that the translation unit is
- * invalid. In such cases, the only valid call for \p TU is 
- * \c clang_disposeTranslationUnit(TU).
+ * invalid. In such cases, the only valid call for \c TU is
+ * \c clang_disposeTranslationUnit(TU).  The error codes returned by this
+ * routine are described by the \c CXErrorCode enum.
  */
 CINDEX_LINKAGE int clang_reparseTranslationUnit(CXTranslationUnit TU,
                                                 unsigned num_unsaved_files,
@@ -1504,7 +1603,7 @@ enum CXCursorKind {
   CXCursor_ObjCImplementationDecl        = 18,
   /** \brief An Objective-C \@implementation for a category. */
   CXCursor_ObjCCategoryImplDecl          = 19,
-  /** \brief A typedef */
+  /** \brief A typedef. */
   CXCursor_TypedefDecl                   = 20,
   /** \brief A C++ class method. */
   CXCursor_CXXMethod                     = 21,
@@ -1671,7 +1770,7 @@ enum CXCursorKind {
 
   /**
    * \brief An expression that refers to some value declaration, such
-   * as a function, varible, or enumerator.
+   * as a function, variable, or enumerator.
    */
   CXCursor_DeclRefExpr                   = 101,
 
@@ -1835,7 +1934,7 @@ enum CXCursorKind {
    */
   CXCursor_CXXDeleteExpr                 = 135,
 
-  /** \brief A unary expression.
+  /** \brief A unary expression. (noexcept, sizeof, or other traits)
    */
   CXCursor_UnaryExpr                     = 136,
 
@@ -1909,11 +2008,19 @@ enum CXCursorKind {
    */
   CXCursor_ObjCBoolLiteralExpr           = 145,
 
-  /** \brief Represents the "self" expression in a ObjC method.
+  /** \brief Represents the "self" expression in an Objective-C method.
    */
   CXCursor_ObjCSelfExpr                  = 146,
 
-  CXCursor_LastExpr                      = CXCursor_ObjCSelfExpr,
+  /** \brief OpenMP 4.0 [2.4, Array Section].
+   */
+  CXCursor_OMPArraySectionExpr           = 147,
+
+  /** \brief Represents an @available(...) check.
+   */
+  CXCursor_ObjCAvailabilityCheckExpr     = 148,
+
+  CXCursor_LastExpr                      = CXCursor_ObjCAvailabilityCheckExpr,
 
   /* Statements */
   CXCursor_FirstStmt                     = 200,
@@ -2057,7 +2164,7 @@ enum CXCursorKind {
    */
   CXCursor_MSAsmStmt                     = 229,
 
-  /** \brief The null satement ";": C99 6.8.3p3.
+  /** \brief The null statement ";": C99 6.8.3p3.
    *
    * This cursor kind is used to describe the null statement.
    */
@@ -2072,7 +2179,155 @@ enum CXCursorKind {
    */
   CXCursor_OMPParallelDirective          = 232,
 
-  CXCursor_LastStmt                      = CXCursor_OMPParallelDirective,
+  /** \brief OpenMP SIMD directive.
+   */
+  CXCursor_OMPSimdDirective              = 233,
+
+  /** \brief OpenMP for directive.
+   */
+  CXCursor_OMPForDirective               = 234,
+
+  /** \brief OpenMP sections directive.
+   */
+  CXCursor_OMPSectionsDirective          = 235,
+
+  /** \brief OpenMP section directive.
+   */
+  CXCursor_OMPSectionDirective           = 236,
+
+  /** \brief OpenMP single directive.
+   */
+  CXCursor_OMPSingleDirective            = 237,
+
+  /** \brief OpenMP parallel for directive.
+   */
+  CXCursor_OMPParallelForDirective       = 238,
+
+  /** \brief OpenMP parallel sections directive.
+   */
+  CXCursor_OMPParallelSectionsDirective  = 239,
+
+  /** \brief OpenMP task directive.
+   */
+  CXCursor_OMPTaskDirective              = 240,
+
+  /** \brief OpenMP master directive.
+   */
+  CXCursor_OMPMasterDirective            = 241,
+
+  /** \brief OpenMP critical directive.
+   */
+  CXCursor_OMPCriticalDirective          = 242,
+
+  /** \brief OpenMP taskyield directive.
+   */
+  CXCursor_OMPTaskyieldDirective         = 243,
+
+  /** \brief OpenMP barrier directive.
+   */
+  CXCursor_OMPBarrierDirective           = 244,
+
+  /** \brief OpenMP taskwait directive.
+   */
+  CXCursor_OMPTaskwaitDirective          = 245,
+
+  /** \brief OpenMP flush directive.
+   */
+  CXCursor_OMPFlushDirective             = 246,
+
+  /** \brief Windows Structured Exception Handling's leave statement.
+   */
+  CXCursor_SEHLeaveStmt                  = 247,
+
+  /** \brief OpenMP ordered directive.
+   */
+  CXCursor_OMPOrderedDirective           = 248,
+
+  /** \brief OpenMP atomic directive.
+   */
+  CXCursor_OMPAtomicDirective            = 249,
+
+  /** \brief OpenMP for SIMD directive.
+   */
+  CXCursor_OMPForSimdDirective           = 250,
+
+  /** \brief OpenMP parallel for SIMD directive.
+   */
+  CXCursor_OMPParallelForSimdDirective   = 251,
+
+  /** \brief OpenMP target directive.
+   */
+  CXCursor_OMPTargetDirective            = 252,
+
+  /** \brief OpenMP teams directive.
+   */
+  CXCursor_OMPTeamsDirective             = 253,
+
+  /** \brief OpenMP taskgroup directive.
+   */
+  CXCursor_OMPTaskgroupDirective         = 254,
+
+  /** \brief OpenMP cancellation point directive.
+   */
+  CXCursor_OMPCancellationPointDirective = 255,
+
+  /** \brief OpenMP cancel directive.
+   */
+  CXCursor_OMPCancelDirective            = 256,
+
+  /** \brief OpenMP target data directive.
+   */
+  CXCursor_OMPTargetDataDirective        = 257,
+
+  /** \brief OpenMP taskloop directive.
+   */
+  CXCursor_OMPTaskLoopDirective          = 258,
+
+  /** \brief OpenMP taskloop simd directive.
+   */
+  CXCursor_OMPTaskLoopSimdDirective      = 259,
+
+  /** \brief OpenMP distribute directive.
+   */
+  CXCursor_OMPDistributeDirective        = 260,
+
+  /** \brief OpenMP target enter data directive.
+   */
+  CXCursor_OMPTargetEnterDataDirective   = 261,
+
+  /** \brief OpenMP target exit data directive.
+   */
+  CXCursor_OMPTargetExitDataDirective    = 262,
+
+  /** \brief OpenMP target parallel directive.
+   */
+  CXCursor_OMPTargetParallelDirective    = 263,
+
+  /** \brief OpenMP target parallel for directive.
+   */
+  CXCursor_OMPTargetParallelForDirective = 264,
+
+  /** \brief OpenMP target update directive.
+   */
+  CXCursor_OMPTargetUpdateDirective      = 265,
+
+  /** \brief OpenMP distribute parallel for directive.
+   */
+  CXCursor_OMPDistributeParallelForDirective = 266,
+
+  /** \brief OpenMP distribute parallel for simd directive.
+   */
+  CXCursor_OMPDistributeParallelForSimdDirective = 267,
+
+  /** \brief OpenMP distribute simd directive.
+   */
+  CXCursor_OMPDistributeSimdDirective = 268,
+
+  /** \brief OpenMP target parallel for simd directive.
+   */
+  CXCursor_OMPTargetParallelForSimdDirective = 269,
+
+  CXCursor_LastStmt = CXCursor_OMPTargetParallelForSimdDirective,
 
   /**
    * \brief Cursor that represents the translation unit itself.
@@ -2098,8 +2353,19 @@ enum CXCursorKind {
   CXCursor_AnnotateAttr                  = 406,
   CXCursor_AsmLabelAttr                  = 407,
   CXCursor_PackedAttr                    = 408,
-  CXCursor_LastAttr                      = CXCursor_PackedAttr,
-     
+  CXCursor_PureAttr                      = 409,
+  CXCursor_ConstAttr                     = 410,
+  CXCursor_NoDuplicateAttr               = 411,
+  CXCursor_CUDAConstantAttr              = 412,
+  CXCursor_CUDADeviceAttr                = 413,
+  CXCursor_CUDAGlobalAttr                = 414,
+  CXCursor_CUDAHostAttr                  = 415,
+  CXCursor_CUDASharedAttr                = 416,
+  CXCursor_VisibilityAttr                = 417,
+  CXCursor_DLLExport                     = 418,
+  CXCursor_DLLImport                     = 419,
+  CXCursor_LastAttr                      = CXCursor_DLLImport,
+
   /* Preprocessing */
   CXCursor_PreprocessingDirective        = 500,
   CXCursor_MacroDefinition               = 501,
@@ -2114,8 +2380,18 @@ enum CXCursorKind {
    * \brief A module import declaration.
    */
   CXCursor_ModuleImportDecl              = 600,
+  CXCursor_TypeAliasTemplateDecl         = 601,
+  /**
+   * \brief A static_assert or _Static_assert node
+   */
+  CXCursor_StaticAssert                  = 602,
   CXCursor_FirstExtraDecl                = CXCursor_ModuleImportDecl,
-  CXCursor_LastExtraDecl                 = CXCursor_ModuleImportDecl
+  CXCursor_LastExtraDecl                 = CXCursor_StaticAssert,
+
+  /**
+   * \brief A code completion overload candidate.
+   */
+  CXCursor_OverloadCandidate             = 700
 };
 
 /**
@@ -2141,14 +2417,6 @@ typedef struct {
   int xdata;
   uintptr_t data[3];
 } CXCursor;
-
-/**
- * \brief A comment AST node.
- */
-typedef struct {
-  uintptr_t ASTNode;
-  CXTranslationUnit TranslationUnit;
-} CXComment;
 
 /**
  * \defgroup CINDEX_CURSOR_MANIP Cursor manipulations
@@ -2220,6 +2488,11 @@ CINDEX_LINKAGE unsigned clang_isStatement(enum CXCursorKind);
 CINDEX_LINKAGE unsigned clang_isAttribute(enum CXCursorKind);
 
 /**
+ * \brief Determine whether the given cursor has any attributes.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_hasAttrs(CXCursor C);
+
+/**
  * \brief Determine whether the given cursor kind represents an invalid
  * cursor.
  */
@@ -2269,6 +2542,32 @@ enum CXLinkageKind {
  */
 CINDEX_LINKAGE enum CXLinkageKind clang_getCursorLinkage(CXCursor cursor);
 
+enum CXVisibilityKind {
+  /** \brief This value indicates that no visibility information is available
+   * for a provided CXCursor. */
+  CXVisibility_Invalid,
+
+  /** \brief Symbol not seen by the linker. */
+  CXVisibility_Hidden,
+  /** \brief Symbol seen by the linker but resolves to a symbol inside this object. */
+  CXVisibility_Protected,
+  /** \brief Symbol seen by the linker and acts like a normal symbol. */
+  CXVisibility_Default
+};
+
+/**
+ * \brief Describe the visibility of the entity referred to by a cursor.
+ *
+ * This returns the default visibility if not explicitly specified by
+ * a visibility attribute. The default visibility may be changed by
+ * commandline arguments.
+ *
+ * \param cursor The cursor to query.
+ *
+ * \returns The visibility of the cursor.
+ */
+CINDEX_LINKAGE enum CXVisibilityKind clang_getCursorVisibility(CXCursor cursor);
+
 /**
  * \brief Determine the availability of the entity that this cursor refers to,
  * taking the current target platform into account.
@@ -2289,7 +2588,7 @@ typedef struct CXPlatformAvailability {
    * \brief A string that describes the platform for which this structure
    * provides availability information.
    *
-   * Possible values are "ios" or "macosx".
+   * Possible values are "ios" or "macos".
    */
   CXString Platform;
   /**
@@ -2371,7 +2670,7 @@ clang_disposeCXPlatformAvailability(CXPlatformAvailability *availability);
 /**
  * \brief Describe the "language" of the entity referred to by a cursor.
  */
-CINDEX_LINKAGE enum CXLanguageKind {
+enum CXLanguageKind {
   CXLanguage_Invalid = 0,
   CXLanguage_C,
   CXLanguage_ObjC,
@@ -2387,7 +2686,6 @@ CINDEX_LINKAGE enum CXLanguageKind clang_getCursorLanguage(CXCursor cursor);
  * \brief Returns the translation unit that a cursor originated from.
  */
 CINDEX_LINKAGE CXTranslationUnit clang_Cursor_getTranslationUnit(CXCursor);
-
 
 /**
  * \brief A fast container representing a set of CXCursors.
@@ -2437,10 +2735,10 @@ CINDEX_LINKAGE unsigned clang_CXCursorSet_insert(CXCursorSet cset,
  * void C::f() { }
  * \endcode
  *
- * In the out-of-line definition of \c C::f, the semantic parent is the 
+ * In the out-of-line definition of \c C::f, the semantic parent is
  * the class \c C, of which this function is a member. The lexical parent is
  * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the 
+ * case, the definition occurs in the translation unit. In general, the
  * lexical parent for a given entity can change without affecting the semantics
  * of the program, and the lexical parent of different declarations of the
  * same entity may be different. Changing the semantic parent of a declaration,
@@ -2472,10 +2770,10 @@ CINDEX_LINKAGE CXCursor clang_getCursorSemanticParent(CXCursor cursor);
  * void C::f() { }
  * \endcode
  *
- * In the out-of-line definition of \c C::f, the semantic parent is the 
+ * In the out-of-line definition of \c C::f, the semantic parent is
  * the class \c C, of which this function is a member. The lexical parent is
  * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the 
+ * case, the definition occurs in the translation unit. In general, the
  * lexical parent for a given entity can change without affecting the semantics
  * of the program, and the lexical parent of different declarations of the
  * same entity may be different. Changing the semantic parent of a declaration,
@@ -2600,7 +2898,7 @@ CINDEX_LINKAGE CXSourceLocation clang_getCursorLocation(CXCursor);
  *
  * The extent of a cursor starts with the file/line/column pointing at the
  * first character within the source construct that the cursor refers to and
- * ends with the last character withinin that source construct. For a
+ * ends with the last character within that source construct. For a
  * declaration, the extent covers the declaration itself. For a reference,
  * the extent covers the location of the reference (e.g., where the referenced
  * entity was actually used).
@@ -2622,7 +2920,7 @@ CINDEX_LINKAGE CXSourceRange clang_getCursorExtent(CXCursor);
  */
 enum CXTypeKind {
   /**
-   * \brief Reprents an invalid type (e.g., where no type is available).
+   * \brief Represents an invalid type (e.g., where no type is available).
    */
   CXType_Invalid = 0,
 
@@ -2661,6 +2959,7 @@ enum CXTypeKind {
   CXType_ObjCId = 27,
   CXType_ObjCClass = 28,
   CXType_ObjCSel = 29,
+  CXType_Float128 = 30,
   CXType_FirstBuiltin = CXType_Void,
   CXType_LastBuiltin  = CXType_ObjCSel,
 
@@ -2681,7 +2980,15 @@ enum CXTypeKind {
   CXType_IncompleteArray = 114,
   CXType_VariableArray = 115,
   CXType_DependentSizedArray = 116,
-  CXType_MemberPointer = 117
+  CXType_MemberPointer = 117,
+  CXType_Auto = 118,
+
+  /**
+   * \brief Represents a type that was referred to using an elaborated type keyword.
+   *
+   * E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+   */
+  CXType_Elaborated = 119
 };
 
 /**
@@ -2696,15 +3003,18 @@ enum CXCallingConv {
   CXCallingConv_X86Pascal = 5,
   CXCallingConv_AAPCS = 6,
   CXCallingConv_AAPCS_VFP = 7,
-  CXCallingConv_PnaclCall = 8,
+  /* Value 8 was PnaclCall, but it was never used, so it could safely be re-used. */
   CXCallingConv_IntelOclBicc = 9,
   CXCallingConv_X86_64Win64 = 10,
   CXCallingConv_X86_64SysV = 11,
+  CXCallingConv_X86VectorCall = 12,
+  CXCallingConv_Swift = 13,
+  CXCallingConv_PreserveMost = 14,
+  CXCallingConv_PreserveAll = 15,
 
   CXCallingConv_Invalid = 100,
   CXCallingConv_Unexposed = 200
 };
-
 
 /**
  * \brief The type of an element in the abstract syntax tree.
@@ -2790,6 +3100,124 @@ CINDEX_LINKAGE int clang_Cursor_getNumArguments(CXCursor C);
 CINDEX_LINKAGE CXCursor clang_Cursor_getArgument(CXCursor C, unsigned i);
 
 /**
+ * \brief Describes the kind of a template argument.
+ *
+ * See the definition of llvm::clang::TemplateArgument::ArgKind for full
+ * element descriptions.
+ */
+enum CXTemplateArgumentKind {
+  CXTemplateArgumentKind_Null,
+  CXTemplateArgumentKind_Type,
+  CXTemplateArgumentKind_Declaration,
+  CXTemplateArgumentKind_NullPtr,
+  CXTemplateArgumentKind_Integral,
+  CXTemplateArgumentKind_Template,
+  CXTemplateArgumentKind_TemplateExpansion,
+  CXTemplateArgumentKind_Expression,
+  CXTemplateArgumentKind_Pack,
+  /* Indicates an error case, preventing the kind from being deduced. */
+  CXTemplateArgumentKind_Invalid
+};
+
+/**
+ *\brief Returns the number of template args of a function decl representing a
+ * template specialization.
+ *
+ * If the argument cursor cannot be converted into a template function
+ * declaration, -1 is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * The value 3 would be returned from this call.
+ */
+CINDEX_LINKAGE int clang_Cursor_getNumTemplateArguments(CXCursor C);
+
+/**
+ * \brief Retrieve the kind of the I'th template argument of the CXCursor C.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl, an invalid
+ * template argument kind is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+ * respectively.
+ */
+CINDEX_LINKAGE enum CXTemplateArgumentKind clang_Cursor_getTemplateArgumentKind(
+    CXCursor C, unsigned I);
+
+/**
+ * \brief Retrieve a CXType representing the type of a TemplateArgument of a
+ *  function decl representing a template specialization.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl whose I'th
+ * template argument has a kind of CXTemplateArgKind_Integral, an invalid type
+ * is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 0, "float", will be returned.
+ * Invalid types will be returned for I == 1 or 2.
+ */
+CINDEX_LINKAGE CXType clang_Cursor_getTemplateArgumentType(CXCursor C,
+                                                           unsigned I);
+
+/**
+ * \brief Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as a signed long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl or whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 1 or 2, -7 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE long long clang_Cursor_getTemplateArgumentValue(CXCursor C,
+                                                               unsigned I);
+
+/**
+ * \brief Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as an unsigned long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl or whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, 2147483649, true>();
+ *
+ * If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE unsigned long long clang_Cursor_getTemplateArgumentUnsignedValue(
+    CXCursor C, unsigned I);
+
+/**
  * \brief Determine whether two CXTypes represent the same type.
  *
  * \returns non-zero if the CXTypes represent the same type and
@@ -2813,6 +3241,24 @@ CINDEX_LINKAGE CXType clang_getCanonicalType(CXType T);
  * different level.
  */
 CINDEX_LINKAGE unsigned clang_isConstQualifiedType(CXType T);
+
+/**
+ * \brief Determine whether a  CXCursor that is a macro, is
+ * function like.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isMacroFunctionLike(CXCursor C);
+
+/**
+ * \brief Determine whether a  CXCursor that is a macro, is a
+ * builtin one.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isMacroBuiltin(CXCursor C);
+
+/**
+ * \brief Determine whether a  CXCursor that is a function declaration, is an
+ * inline declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isFunctionInlined(CXCursor C);
 
 /**
  * \brief Determine whether a CXType has the "volatile" qualifier set,
@@ -2844,6 +3290,11 @@ CINDEX_LINKAGE CXCursor clang_getTypeDeclaration(CXType T);
 CINDEX_LINKAGE CXString clang_getDeclObjCTypeEncoding(CXCursor C);
 
 /**
+ * Returns the Objective-C type encoding for the specified CXType.
+ */
+CINDEX_LINKAGE CXString clang_Type_getObjCEncoding(CXType type); 
+
+/**
  * \brief Retrieve the spelling of a given CXTypeKind.
  */
 CINDEX_LINKAGE CXString clang_getTypeKindSpelling(enum CXTypeKind K);
@@ -2856,14 +3307,14 @@ CINDEX_LINKAGE CXString clang_getTypeKindSpelling(enum CXTypeKind K);
 CINDEX_LINKAGE enum CXCallingConv clang_getFunctionTypeCallingConv(CXType T);
 
 /**
- * \brief Retrieve the result type associated with a function type.
+ * \brief Retrieve the return type associated with a function type.
  *
  * If a non-function type is passed in, an invalid type is returned.
  */
 CINDEX_LINKAGE CXType clang_getResultType(CXType T);
 
 /**
- * \brief Retrieve the number of non-variadic arguments associated with a
+ * \brief Retrieve the number of non-variadic parameters associated with a
  * function type.
  *
  * If a non-function type is passed in, -1 is returned.
@@ -2871,7 +3322,7 @@ CINDEX_LINKAGE CXType clang_getResultType(CXType T);
 CINDEX_LINKAGE int clang_getNumArgTypes(CXType T);
 
 /**
- * \brief Retrieve the type of an argument of a function type.
+ * \brief Retrieve the type of a parameter of a function type.
  *
  * If a non-function type is passed in or the function does not have enough
  * parameters, an invalid type is returned.
@@ -2884,7 +3335,7 @@ CINDEX_LINKAGE CXType clang_getArgType(CXType T, unsigned i);
 CINDEX_LINKAGE unsigned clang_isFunctionTypeVariadic(CXType T);
 
 /**
- * \brief Retrieve the result type associated with a given cursor.
+ * \brief Retrieve the return type associated with a given cursor.
  *
  * This only returns a valid type if the cursor refers to a function or method.
  */
@@ -2925,6 +3376,13 @@ CINDEX_LINKAGE CXType clang_getArrayElementType(CXType T);
  * If a non-array type is passed in, -1 is returned.
  */
 CINDEX_LINKAGE long long clang_getArraySize(CXType T);
+
+/**
+ * \brief Retrieve the type named by the qualified-id.
+ *
+ * If a non-elaborated type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getNamedType(CXType T);
 
 /**
  * \brief List the possible error codes for \c clang_Type_getSizeOf,
@@ -3004,6 +3462,27 @@ CINDEX_LINKAGE long long clang_Type_getSizeOf(CXType T);
  */
 CINDEX_LINKAGE long long clang_Type_getOffsetOf(CXType T, const char *S);
 
+/**
+ * \brief Return the offset of the field represented by the Cursor.
+ *
+ * If the cursor is not a field declaration, -1 is returned.
+ * If the cursor semantic parent is not a record field declaration,
+ *   CXTypeLayoutError_Invalid is returned.
+ * If the field's type declaration is an incomplete type,
+ *   CXTypeLayoutError_Incomplete is returned.
+ * If the field's type declaration is a dependent type,
+ *   CXTypeLayoutError_Dependent is returned.
+ * If the field's name S is not found,
+ *   CXTypeLayoutError_InvalidFieldName is returned.
+ */
+CINDEX_LINKAGE long long clang_Cursor_getOffsetOfField(CXCursor C);
+
+/**
+ * \brief Determine whether the given cursor represents an anonymous record
+ * declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isAnonymous(CXCursor C);
+
 enum CXRefQualifierKind {
   /** \brief No ref-qualifier was provided. */
   CXRefQualifier_None = 0,
@@ -3012,6 +3491,24 @@ enum CXRefQualifierKind {
   /** \brief An rvalue ref-qualifier was provided (\c &&). */
   CXRefQualifier_RValue
 };
+
+/**
+ * \brief Returns the number of template arguments for given class template
+ * specialization, or -1 if type \c T is not a class template specialization.
+ *
+ * Variadic argument packs count as only one argument, and can not be inspected
+ * further.
+ */
+CINDEX_LINKAGE int clang_Type_getNumTemplateArguments(CXType T);
+
+/**
+ * \brief Returns the type template argument of a template class specialization
+ * at given index.
+ *
+ * This function only returns template type arguments and does not handle
+ * template template arguments or variadic packs.
+ */
+CINDEX_LINKAGE CXType clang_Type_getTemplateArgumentAsType(CXType T, unsigned i);
 
 /**
  * \brief Retrieve the ref-qualifier kind of a function or method.
@@ -3054,6 +3551,29 @@ enum CX_CXXAccessSpecifier {
 CINDEX_LINKAGE enum CX_CXXAccessSpecifier clang_getCXXAccessSpecifier(CXCursor);
 
 /**
+ * \brief Represents the storage classes as declared in the source. CX_SC_Invalid
+ * was added for the case that the passed cursor in not a declaration.
+ */
+enum CX_StorageClass {
+  CX_SC_Invalid,
+  CX_SC_None,
+  CX_SC_Extern,
+  CX_SC_Static,
+  CX_SC_PrivateExtern,
+  CX_SC_OpenCLWorkGroupLocal,
+  CX_SC_Auto,
+  CX_SC_Register
+};
+
+/**
+ * \brief Returns the storage class for a function or variable declaration.
+ *
+ * If the passed in Cursor is not a function or variable declaration,
+ * CX_SC_Invalid is returned else the storage class.
+ */
+CINDEX_LINKAGE enum CX_StorageClass clang_Cursor_getStorageClass(CXCursor);
+
+/**
  * \brief Determine the number of overloaded declarations referenced by a 
  * \c CXCursor_OverloadedDeclRef cursor.
  *
@@ -3090,7 +3610,6 @@ CINDEX_LINKAGE CXCursor clang_getOverloadedDecl(CXCursor cursor,
  *
  * @{
  */
-
 
 /**
  * \brief For cursors representing an iboutletcollection attribute,
@@ -3196,8 +3715,8 @@ typedef enum CXChildVisitResult
  * Visits the children of a cursor using the specified block.  Behaves
  * identically to clang_visitChildren() in all other respects.
  */
-unsigned clang_visitChildrenWithBlock(CXCursor parent,
-                                      CXCursorVisitorBlock block);
+CINDEX_LINKAGE unsigned clang_visitChildrenWithBlock(CXCursor parent,
+                                                    CXCursorVisitorBlock block);
 #  endif
 #endif
 
@@ -3245,7 +3764,6 @@ CINDEX_LINKAGE CXString
 CINDEX_LINKAGE CXString
   clang_constructUSR_ObjCProtocol(const char *protocol_name);
 
-
 /**
  * \brief Construct a USR for a specified Objective-C instance variable and
  *   the USR for its containing class.
@@ -3276,8 +3794,8 @@ CINDEX_LINKAGE CXString clang_getCursorSpelling(CXCursor);
 /**
  * \brief Retrieve a range for a piece that forms the cursors spelling name.
  * Most of the times there is only one range for the complete spelling but for
- * objc methods and objc message expressions, there are multiple pieces for each
- * selector identifier.
+ * Objective-C methods and Objective-C message expressions, there are multiple
+ * pieces for each selector identifier.
  * 
  * \param pieceIndex the index of the spelling name piece. If this is greater
  * than the actual number of pieces, it will return a NULL (invalid) range.
@@ -3371,27 +3889,26 @@ CINDEX_LINKAGE unsigned clang_isCursorDefinition(CXCursor);
  */
 CINDEX_LINKAGE CXCursor clang_getCanonicalCursor(CXCursor);
 
-
 /**
- * \brief If the cursor points to a selector identifier in a objc method or
- * message expression, this returns the selector index.
+ * \brief If the cursor points to a selector identifier in an Objective-C
+ * method or message expression, this returns the selector index.
  *
  * After getting a cursor with #clang_getCursor, this can be called to
  * determine if the location points to a selector identifier.
  *
- * \returns The selector index if the cursor is an objc method or message
+ * \returns The selector index if the cursor is an Objective-C method or message
  * expression and the cursor is pointing to a selector identifier, or -1
  * otherwise.
  */
 CINDEX_LINKAGE int clang_Cursor_getObjCSelectorIndex(CXCursor);
 
 /**
- * \brief Given a cursor pointing to a C++ method call or an ObjC message,
- * returns non-zero if the method/message is "dynamic", meaning:
+ * \brief Given a cursor pointing to a C++ method call or an Objective-C
+ * message, returns non-zero if the method/message is "dynamic", meaning:
  * 
  * For a C++ method: the call is virtual.
- * For an ObjC message: the receiver is an object instance, not 'super' or a
- * specific class.
+ * For an Objective-C message: the receiver is an object instance, not 'super'
+ * or a specific class.
  * 
  * If the method/message is "static" or the cursor does not point to a
  * method/message, it will return zero.
@@ -3399,8 +3916,8 @@ CINDEX_LINKAGE int clang_Cursor_getObjCSelectorIndex(CXCursor);
 CINDEX_LINKAGE int clang_Cursor_isDynamicCall(CXCursor C);
 
 /**
- * \brief Given a cursor pointing to an ObjC message, returns the CXType of the
- * receiver.
+ * \brief Given a cursor pointing to an Objective-C message, returns the CXType
+ * of the receiver.
  */
 CINDEX_LINKAGE CXType clang_Cursor_getReceiverType(CXCursor C);
 
@@ -3420,7 +3937,8 @@ typedef enum {
   CXObjCPropertyAttr_atomic    = 0x100,
   CXObjCPropertyAttr_weak      = 0x200,
   CXObjCPropertyAttr_strong    = 0x400,
-  CXObjCPropertyAttr_unsafe_unretained = 0x800
+  CXObjCPropertyAttr_unsafe_unretained = 0x800,
+  CXObjCPropertyAttr_class = 0x1000
 } CXObjCPropertyAttrKind;
 
 /**
@@ -3435,7 +3953,7 @@ CINDEX_LINKAGE unsigned clang_Cursor_getObjCPropertyAttributes(CXCursor C,
 
 /**
  * \brief 'Qualifiers' written next to the return and parameter types in
- * ObjC method declarations.
+ * Objective-C method declarations.
  */
 typedef enum {
   CXObjCDeclQualifier_None = 0x0,
@@ -3448,15 +3966,16 @@ typedef enum {
 } CXObjCDeclQualifierKind;
 
 /**
- * \brief Given a cursor that represents an ObjC method or parameter
- * declaration, return the associated ObjC qualifiers for the return type or the
- * parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
+ * \brief Given a cursor that represents an Objective-C method or parameter
+ * declaration, return the associated Objective-C qualifiers for the return
+ * type or the parameter respectively. The bits are formed from
+ * CXObjCDeclQualifierKind.
  */
 CINDEX_LINKAGE unsigned clang_Cursor_getObjCDeclQualifiers(CXCursor C);
 
 /**
- * \brief Given a cursor that represents an ObjC method or property declaration,
- * return non-zero if the declaration was affected by "@optional".
+ * \brief Given a cursor that represents an Objective-C method or property
+ * declaration, return non-zero if the declaration was affected by "@optional".
  * Returns zero if the cursor is not such a declaration or it is "@required".
  */
 CINDEX_LINKAGE unsigned clang_Cursor_isObjCOptional(CXCursor C);
@@ -3487,11 +4006,24 @@ CINDEX_LINKAGE CXString clang_Cursor_getRawCommentText(CXCursor C);
 CINDEX_LINKAGE CXString clang_Cursor_getBriefCommentText(CXCursor C);
 
 /**
- * \brief Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated parsed comment as a
- * \c CXComment_FullComment AST node.
+ * @}
  */
-CINDEX_LINKAGE CXComment clang_Cursor_getParsedComment(CXCursor C);
+
+/** \defgroup CINDEX_MANGLE Name Mangling API Functions
+ *
+ * @{
+ */
+
+/**
+ * \brief Retrieve the CXString representing the mangled name of the cursor.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getMangling(CXCursor);
+
+/**
+ * \brief Retrieve the CXStrings representing the mangled symbols of the C++
+ * constructor or destructor at the cursor.
+ */
+CINDEX_LINKAGE CXStringSet *clang_Cursor_getCXXManglings(CXCursor);
 
 /**
  * @}
@@ -3511,6 +4043,12 @@ typedef void *CXModule;
  * \brief Given a CXCursor_ModuleImportDecl cursor, return the associated module.
  */
 CINDEX_LINKAGE CXModule clang_Cursor_getModule(CXCursor C);
+
+/**
+ * \brief Given a CXFile header file, return the module that contains it, if one
+ * exists.
+ */
+CINDEX_LINKAGE CXModule clang_getModuleForFile(CXTranslationUnit, CXFile);
 
 /**
  * \param Module a module object.
@@ -3545,6 +4083,13 @@ CINDEX_LINKAGE CXString clang_Module_getFullName(CXModule Module);
 /**
  * \param Module a module object.
  *
+ * \returns non-zero if the module is a system one.
+ */
+CINDEX_LINKAGE int clang_Module_isSystem(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
  * \returns the number of top level headers associated with this module.
  */
 CINDEX_LINKAGE unsigned clang_Module_getNumTopLevelHeaders(CXTranslationUnit,
@@ -3566,514 +4111,6 @@ CXFile clang_Module_getTopLevelHeader(CXTranslationUnit,
  */
 
 /**
- * \defgroup CINDEX_COMMENT Comment AST introspection
- *
- * The routines in this group provide access to information in the
- * documentation comment ASTs.
- *
- * @{
- */
-
-/**
- * \brief Describes the type of the comment AST node (\c CXComment).  A comment
- * node can be considered block content (e. g., paragraph), inline content
- * (plain text) or neither (the root AST node).
- */
-enum CXCommentKind {
-  /**
-   * \brief Null comment.  No AST node is constructed at the requested location
-   * because there is no text or a syntax error.
-   */
-  CXComment_Null = 0,
-
-  /**
-   * \brief Plain text.  Inline content.
-   */
-  CXComment_Text = 1,
-
-  /**
-   * \brief A command with word-like arguments that is considered inline content.
-   *
-   * For example: \\c command.
-   */
-  CXComment_InlineCommand = 2,
-
-  /**
-   * \brief HTML start tag with attributes (name-value pairs).  Considered
-   * inline content.
-   *
-   * For example:
-   * \verbatim
-   * <br> <br /> <a href="http://example.org/">
-   * \endverbatim
-   */
-  CXComment_HTMLStartTag = 3,
-
-  /**
-   * \brief HTML end tag.  Considered inline content.
-   *
-   * For example:
-   * \verbatim
-   * </a>
-   * \endverbatim
-   */
-  CXComment_HTMLEndTag = 4,
-
-  /**
-   * \brief A paragraph, contains inline comment.  The paragraph itself is
-   * block content.
-   */
-  CXComment_Paragraph = 5,
-
-  /**
-   * \brief A command that has zero or more word-like arguments (number of
-   * word-like arguments depends on command name) and a paragraph as an
-   * argument.  Block command is block content.
-   *
-   * Paragraph argument is also a child of the block command.
-   *
-   * For example: \\brief has 0 word-like arguments and a paragraph argument.
-   *
-   * AST nodes of special kinds that parser knows about (e. g., \\param
-   * command) have their own node kinds.
-   */
-  CXComment_BlockCommand = 6,
-
-  /**
-   * \brief A \\param or \\arg command that describes the function parameter
-   * (name, passing direction, description).
-   *
-   * For example: \\param [in] ParamName description.
-   */
-  CXComment_ParamCommand = 7,
-
-  /**
-   * \brief A \\tparam command that describes a template parameter (name and
-   * description).
-   *
-   * For example: \\tparam T description.
-   */
-  CXComment_TParamCommand = 8,
-
-  /**
-   * \brief A verbatim block command (e. g., preformatted code).  Verbatim
-   * block has an opening and a closing command and contains multiple lines of
-   * text (\c CXComment_VerbatimBlockLine child nodes).
-   *
-   * For example:
-   * \\verbatim
-   * aaa
-   * \\endverbatim
-   */
-  CXComment_VerbatimBlockCommand = 9,
-
-  /**
-   * \brief A line of text that is contained within a
-   * CXComment_VerbatimBlockCommand node.
-   */
-  CXComment_VerbatimBlockLine = 10,
-
-  /**
-   * \brief A verbatim line command.  Verbatim line has an opening command,
-   * a single line of text (up to the newline after the opening command) and
-   * has no closing command.
-   */
-  CXComment_VerbatimLine = 11,
-
-  /**
-   * \brief A full comment attached to a declaration, contains block content.
-   */
-  CXComment_FullComment = 12
-};
-
-/**
- * \brief The most appropriate rendering mode for an inline command, chosen on
- * command semantics in Doxygen.
- */
-enum CXCommentInlineCommandRenderKind {
-  /**
-   * \brief Command argument should be rendered in a normal font.
-   */
-  CXCommentInlineCommandRenderKind_Normal,
-
-  /**
-   * \brief Command argument should be rendered in a bold font.
-   */
-  CXCommentInlineCommandRenderKind_Bold,
-
-  /**
-   * \brief Command argument should be rendered in a monospaced font.
-   */
-  CXCommentInlineCommandRenderKind_Monospaced,
-
-  /**
-   * \brief Command argument should be rendered emphasized (typically italic
-   * font).
-   */
-  CXCommentInlineCommandRenderKind_Emphasized
-};
-
-/**
- * \brief Describes parameter passing direction for \\param or \\arg command.
- */
-enum CXCommentParamPassDirection {
-  /**
-   * \brief The parameter is an input parameter.
-   */
-  CXCommentParamPassDirection_In,
-
-  /**
-   * \brief The parameter is an output parameter.
-   */
-  CXCommentParamPassDirection_Out,
-
-  /**
-   * \brief The parameter is an input and output parameter.
-   */
-  CXCommentParamPassDirection_InOut
-};
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns the type of the AST node.
- */
-CINDEX_LINKAGE enum CXCommentKind clang_Comment_getKind(CXComment Comment);
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns number of children of the AST node.
- */
-CINDEX_LINKAGE unsigned clang_Comment_getNumChildren(CXComment Comment);
-
-/**
- * \param Comment AST node of any kind.
- *
- * \param ChildIdx child index (zero-based).
- *
- * \returns the specified child of the AST node.
- */
-CINDEX_LINKAGE
-CXComment clang_Comment_getChild(CXComment Comment, unsigned ChildIdx);
-
-/**
- * \brief A \c CXComment_Paragraph node is considered whitespace if it contains
- * only \c CXComment_Text nodes that are empty or whitespace.
- *
- * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
- * never considered whitespace.
- *
- * \returns non-zero if \c Comment is whitespace.
- */
-CINDEX_LINKAGE unsigned clang_Comment_isWhitespace(CXComment Comment);
-
-/**
- * \returns non-zero if \c Comment is inline content and has a newline
- * immediately following it in the comment text.  Newlines between paragraphs
- * do not count.
- */
-CINDEX_LINKAGE
-unsigned clang_InlineContentComment_hasTrailingNewline(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_Text AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE CXString clang_TextComment_getText(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns name of the inline command.
- */
-CINDEX_LINKAGE
-CXString clang_InlineCommandComment_getCommandName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns the most appropriate rendering mode, chosen on command
- * semantics in Doxygen.
- */
-CINDEX_LINKAGE enum CXCommentInlineCommandRenderKind
-clang_InlineCommandComment_getRenderKind(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns number of command arguments.
- */
-CINDEX_LINKAGE
-unsigned clang_InlineCommandComment_getNumArgs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified argument.
- */
-CINDEX_LINKAGE
-CXString clang_InlineCommandComment_getArgText(CXComment Comment,
-                                               unsigned ArgIdx);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns HTML tag name.
- */
-CINDEX_LINKAGE CXString clang_HTMLTagComment_getTagName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
- */
-CINDEX_LINKAGE
-unsigned clang_HTMLStartTagComment_isSelfClosing(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns number of attributes (name-value pairs) attached to the start tag.
- */
-CINDEX_LINKAGE unsigned clang_HTMLStartTag_getNumAttrs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns name of the specified attribute.
- */
-CINDEX_LINKAGE
-CXString clang_HTMLStartTag_getAttrName(CXComment Comment, unsigned AttrIdx);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns value of the specified attribute.
- */
-CINDEX_LINKAGE
-CXString clang_HTMLStartTag_getAttrValue(CXComment Comment, unsigned AttrIdx);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns name of the block command.
- */
-CINDEX_LINKAGE
-CXString clang_BlockCommandComment_getCommandName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns number of word-like arguments.
- */
-CINDEX_LINKAGE
-unsigned clang_BlockCommandComment_getNumArgs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified word-like argument.
- */
-CINDEX_LINKAGE
-CXString clang_BlockCommandComment_getArgText(CXComment Comment,
-                                              unsigned ArgIdx);
-
-/**
- * \param Comment a \c CXComment_BlockCommand or
- * \c CXComment_VerbatimBlockCommand AST node.
- *
- * \returns paragraph argument of the block command.
- */
-CINDEX_LINKAGE
-CXComment clang_BlockCommandComment_getParagraph(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter name.
- */
-CINDEX_LINKAGE
-CXString clang_ParamCommandComment_getParamName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the function prototype and \c clang_ParamCommandComment_getParamIndex
- * function will return a meaningful value.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_isParamIndexValid(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns zero-based parameter index in function prototype.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_getParamIndex(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if parameter passing direction was specified explicitly in
- * the comment.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_isDirectionExplicit(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter passing direction.
- */
-CINDEX_LINKAGE
-enum CXCommentParamPassDirection clang_ParamCommandComment_getDirection(
-                                                            CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns template parameter name.
- */
-CINDEX_LINKAGE
-CXString clang_TParamCommandComment_getParamName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the template parameter list and
- * \c clang_TParamCommandComment_getDepth and
- * \c clang_TParamCommandComment_getIndex functions will return a meaningful
- * value.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_isParamPositionValid(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based nesting depth of this parameter in the template parameter list.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<int> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0,
- * for T nesting depth is 1.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_getDepth(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based parameter index in the template parameter list at a
- * given nesting depth.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<int> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0, so we can ask for index at depth 0:
- * at depth 0 C's index is 0, TT's index is 1.
- *
- * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
- * at depth 0 T's index is 1 (same as TT's),
- * at depth 1 T's index is 0.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_getIndex(CXComment Comment, unsigned Depth);
-
-/**
- * \param Comment a \c CXComment_VerbatimBlockLine AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE
-CXString clang_VerbatimBlockLineComment_getText(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_VerbatimLine AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE CXString clang_VerbatimLineComment_getText(CXComment Comment);
-
-/**
- * \brief Convert an HTML tag AST node to string.
- *
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns string containing an HTML tag.
- */
-CINDEX_LINKAGE CXString clang_HTMLTagComment_getAsString(CXComment Comment);
-
-/**
- * \brief Convert a given full parsed comment to an HTML fragment.
- *
- * Specific details of HTML layout are subject to change.  Don't try to parse
- * this HTML back into an AST, use other APIs instead.
- *
- * Currently the following CSS classes are used:
- * \li "para-brief" for \\brief paragraph and equivalent commands;
- * \li "para-returns" for \\returns paragraph and equivalent commands;
- * \li "word-returns" for the "Returns" word in \\returns paragraph.
- *
- * Function argument documentation is rendered as a \<dl\> list with arguments
- * sorted in function prototype order.  CSS classes used:
- * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
- * parameter index is invalid.
- *
- * Template parameter documentation is rendered as a \<dl\> list with
- * parameters sorted in template parameter list order.  CSS classes used:
- * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
- * names inside template template parameters;
- * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
- * parameter position is invalid.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an HTML fragment.
- */
-CINDEX_LINKAGE CXString clang_FullComment_getAsHTML(CXComment Comment);
-
-/**
- * \brief Convert a given full parsed comment to an XML document.
- *
- * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
- * inside clang source tree.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an XML document.
- */
-CINDEX_LINKAGE CXString clang_FullComment_getAsXML(CXComment Comment);
-
-/**
- * @}
- */
-
-/**
  * \defgroup CINDEX_CPP C++ AST introspection
  *
  * The routines in this group provide access information in the ASTs specific
@@ -4081,6 +4118,36 @@ CINDEX_LINKAGE CXString clang_FullComment_getAsXML(CXComment Comment);
  *
  * @{
  */
+
+/**
+ * \brief Determine if a C++ constructor is a converting constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isConvertingConstructor(CXCursor C);
+
+/**
+ * \brief Determine if a C++ constructor is a copy constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isCopyConstructor(CXCursor C);
+
+/**
+ * \brief Determine if a C++ constructor is the default constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isDefaultConstructor(CXCursor C);
+
+/**
+ * \brief Determine if a C++ constructor is a move constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isMoveConstructor(CXCursor C);
+
+/**
+ * \brief Determine if a C++ field is declared 'mutable'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXField_isMutable(CXCursor C);
+
+/**
+ * \brief Determine if a C++ method is declared '= default'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isDefaulted(CXCursor C);
 
 /**
  * \brief Determine if a C++ member function or member function template is
@@ -4100,6 +4167,12 @@ CINDEX_LINKAGE unsigned clang_CXXMethod_isStatic(CXCursor C);
  * one of the base classes.
  */
 CINDEX_LINKAGE unsigned clang_CXXMethod_isVirtual(CXCursor C);
+
+/**
+ * \brief Determine if a C++ member function or member function template is
+ * declared 'const'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isConst(CXCursor C);
 
 /**
  * \brief Given a cursor that represents a template, determine
@@ -4191,7 +4264,7 @@ enum CXNameRefFlags {
    * Non-contiguous names occur in Objective-C when a selector with two or more
    * parameters is used, or in C++ when using an operator:
    * \code
-   * [object doSomething:here withValue:there]; // ObjC
+   * [object doSomething:here withValue:there]; // Objective-C
    * return some_vector[1]; // C++
    * \endcode
    */
@@ -4956,7 +5029,7 @@ CINDEX_LINKAGE unsigned clang_defaultCodeCompleteOptions(void);
  * Note that the column should point just after the syntactic construct that
  * initiated code completion, and not in the middle of a lexical token.
  *
- * \param unsaved_files the Tiles that have not yet been saved to disk
+ * \param unsaved_files the Files that have not yet been saved to disk
  * but may be required for parsing or code completion, including the
  * contents of those files.  The contents and name of these files (as
  * specified by CXUnsavedFile) are copied when necessary, so the
@@ -5024,7 +5097,7 @@ CXDiagnostic clang_codeCompleteGetDiagnostic(CXCodeCompleteResults *Results,
                                              unsigned Index);
 
 /**
- * \brief Determines what compeltions are appropriate for the context
+ * \brief Determines what completions are appropriate for the context
  * the given code completion.
  * 
  * \param Results the code completion results to query
@@ -5068,8 +5141,7 @@ enum CXCursorKind clang_codeCompleteGetContainerKind(
  */
 CINDEX_LINKAGE
 CXString clang_codeCompleteGetContainerUSR(CXCodeCompleteResults *Results);
-  
-  
+
 /**
  * \brief Returns the currently-entered selector for an Objective-C message
  * send, formatted like "initWithFoo:bar:". Only guaranteed to return a
@@ -5088,7 +5160,6 @@ CXString clang_codeCompleteGetObjCSelector(CXCodeCompleteResults *Results);
  * @}
  */
 
-
 /**
  * \defgroup CINDEX_MISC Miscellaneous utility functions
  *
@@ -5101,7 +5172,6 @@ CXString clang_codeCompleteGetObjCSelector(CXCodeCompleteResults *Results);
  */
 CINDEX_LINKAGE CXString clang_getClangVersion(void);
 
-  
 /**
  * \brief Enable/disable crash recovery.
  *
@@ -5136,6 +5206,59 @@ CINDEX_LINKAGE void clang_getInclusions(CXTranslationUnit tu,
                                         CXInclusionVisitor visitor,
                                         CXClientData client_data);
 
+typedef enum {
+  CXEval_Int = 1 ,
+  CXEval_Float = 2,
+  CXEval_ObjCStrLiteral = 3,
+  CXEval_StrLiteral = 4,
+  CXEval_CFStr = 5,
+  CXEval_Other = 6,
+
+  CXEval_UnExposed = 0
+
+} CXEvalResultKind ;
+
+/**
+ * \brief Evaluation result of a cursor
+ */
+typedef void * CXEvalResult;
+
+/**
+ * \brief If cursor is a statement declaration tries to evaluate the 
+ * statement and if its variable, tries to evaluate its initializer,
+ * into its corresponding type.
+ */
+CINDEX_LINKAGE CXEvalResult clang_Cursor_Evaluate(CXCursor C);
+
+/**
+ * \brief Returns the kind of the evaluated result.
+ */
+CINDEX_LINKAGE CXEvalResultKind clang_EvalResult_getKind(CXEvalResult E);
+
+/**
+ * \brief Returns the evaluation result as integer if the
+ * kind is Int.
+ */
+CINDEX_LINKAGE int clang_EvalResult_getAsInt(CXEvalResult E);
+
+/**
+ * \brief Returns the evaluation result as double if the
+ * kind is double.
+ */
+CINDEX_LINKAGE double clang_EvalResult_getAsDouble(CXEvalResult E);
+
+/**
+ * \brief Returns the evaluation result as a constant string if the
+ * kind is other than Int or float. User must not free this pointer,
+ * instead call clang_EvalResult_dispose on the CXEvalResult returned
+ * by clang_Cursor_Evaluate.
+ */
+CINDEX_LINKAGE const char* clang_EvalResult_getAsStr(CXEvalResult E);
+
+/**
+ * \brief Disposes the created Eval memory.
+ */
+CINDEX_LINKAGE void clang_EvalResult_dispose(CXEvalResult E);
 /**
  * @}
  */
@@ -5209,7 +5332,7 @@ enum CXVisitorResult {
   CXVisit_Continue
 };
 
-typedef struct {
+typedef struct CXCursorAndRangeVisitor {
   uintptr_t context;
   enum CXVisitorResult (*visit)(void *context, CXCursor, CXSourceRange);
 } CXCursorAndRangeVisitor;
@@ -5474,7 +5597,7 @@ typedef struct {
   const CXIdxContainerInfo *declAsContainer;
   /**
    * \brief Whether the declaration exists in code or was created implicitly
-   * by the compiler, e.g. implicit objc methods for properties.
+   * by the compiler, e.g. implicit Objective-C methods for properties.
    */
   int isImplicit;
   const CXIdxAttrInfo *const *attributes;
@@ -5547,8 +5670,8 @@ typedef enum {
    */
   CXIdxEntityRef_Direct = 1,
   /**
-   * \brief An implicit reference, e.g. a reference of an ObjC method via the
-   * dot syntax.
+   * \brief An implicit reference, e.g. a reference of an Objective-C method
+   * via the dot syntax.
    */
   CXIdxEntityRef_Implicit = 2
 } CXIdxEntityRefKind;
@@ -5742,7 +5865,7 @@ typedef enum {
 
   /**
    * \brief Skip a function/method body that was already parsed during an
-   * indexing session assosiated with a \c CXIndexAction object.
+   * indexing session associated with a \c CXIndexAction object.
    * Bodies in system headers are always skipped.
    */
   CXIndexOpt_SkipParsedBodiesInSession = 0x10
@@ -5765,11 +5888,12 @@ typedef enum {
  * \param index_options A bitmask of options that affects how indexing is
  * performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
  *
- * \param out_TU [out] pointer to store a CXTranslationUnit that can be reused
- * after indexing is finished. Set to NULL if you do not require it.
+ * \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
+ * reused after indexing is finished. Set to \c NULL if you do not require it.
  *
- * \returns If there is a failure from which the there is no recovery, returns
- * non-zero, otherwise returns 0.
+ * \returns 0 on success or if there were errors from which the compiler could
+ * recover.  If there is a failure from which there is no recovery, returns
+ * a non-zero \c CXErrorCode.
  *
  * The rest of the parameters are the same as #clang_parseTranslationUnit.
  */
@@ -5787,6 +5911,18 @@ CINDEX_LINKAGE int clang_indexSourceFile(CXIndexAction,
                                          unsigned TU_options);
 
 /**
+ * \brief Same as clang_indexSourceFile but requires a full command line
+ * for \c command_line_args including argv[0]. This is useful if the standard
+ * library paths are relative to the binary.
+ */
+CINDEX_LINKAGE int clang_indexSourceFileFullArgv(
+    CXIndexAction, CXClientData client_data, IndexerCallbacks *index_callbacks,
+    unsigned index_callbacks_size, unsigned index_options,
+    const char *source_filename, const char *const *command_line_args,
+    int num_command_line_args, struct CXUnsavedFile *unsaved_files,
+    unsigned num_unsaved_files, CXTranslationUnit *out_TU, unsigned TU_options);
+
+/**
  * \brief Index the given translation unit via callbacks implemented through
  * #IndexerCallbacks.
  * 
@@ -5799,7 +5935,7 @@ CINDEX_LINKAGE int clang_indexSourceFile(CXIndexAction,
  *
  * The parameters are the same as #clang_indexSourceFile.
  * 
- * \returns If there is a failure from which the there is no recovery, returns
+ * \returns If there is a failure from which there is no recovery, returns
  * non-zero, otherwise returns 0.
  */
 CINDEX_LINKAGE int clang_indexTranslationUnit(CXIndexAction,
@@ -5831,6 +5967,43 @@ CINDEX_LINKAGE
 CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc);
 
 /**
+ * \brief Visitor invoked for each field found by a traversal.
+ *
+ * This visitor function will be invoked for each field found by
+ * \c clang_Type_visitFields. Its first argument is the cursor being
+ * visited, its second argument is the client data provided to
+ * \c clang_Type_visitFields.
+ *
+ * The visitor should return one of the \c CXVisitorResult values
+ * to direct \c clang_Type_visitFields.
+ */
+typedef enum CXVisitorResult (*CXFieldVisitor)(CXCursor C,
+                                               CXClientData client_data);
+
+/**
+ * \brief Visit the fields of a particular type.
+ *
+ * This function visits all the direct fields of the given cursor,
+ * invoking the given \p visitor function with the cursors of each
+ * visited field. The traversal may be ended prematurely, if
+ * the visitor returns \c CXFieldVisit_Break.
+ *
+ * \param T the record type whose field may be visited.
+ *
+ * \param visitor the visitor function that will be invoked for each
+ * field of \p T.
+ *
+ * \param client_data pointer data supplied by the client, which will
+ * be passed to the visitor each time it is invoked.
+ *
+ * \returns a non-zero value if the traversal was terminated
+ * prematurely by the visitor returning \c CXFieldVisit_Break.
+ */
+CINDEX_LINKAGE unsigned clang_Type_visitFields(CXType T,
+                                               CXFieldVisitor visitor,
+                                               CXClientData client_data);
+
+/**
  * @}
  */
 
@@ -5842,4 +6015,3 @@ CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc);
 }
 #endif
 #endif
-

--- a/clang/clang-c/Platform.h
+++ b/clang/clang-c/Platform.h
@@ -13,8 +13,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_C_PLATFORM_H
-#define CLANG_C_PLATFORM_H
+#ifndef LLVM_CLANG_C_PLATFORM_H
+#define LLVM_CLANG_C_PLATFORM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/clang/clang-c/doc.go
+++ b/clang/clang-c/doc.go
@@ -1,2 +1,2 @@
-// Package clang_c holds clang binding C header files.
+// Package clang-c holds clang binding C header files.
 package clang_c

--- a/clang/clang_gen.go
+++ b/clang/clang_gen.go
@@ -1,9 +1,15 @@
 package clang
 
+// #include "./clang-c/BuildSystem.h"
 // #include "./clang-c/Index.h"
 // #include "go-clang.h"
 import "C"
 import "unsafe"
+
+// Return the timestamp for use with Clang's -fbuild-session-timestamp= option.
+func GetBuildSessionTimestamp() uint64 {
+	return uint64(C.clang_getBuildSessionTimestamp())
+}
 
 /*
 	Retrieve the set of display options most similar to the

--- a/clang/codecompleteresults_gen.go
+++ b/clang/codecompleteresults_gen.go
@@ -43,7 +43,7 @@ func (ccr *CodeCompleteResults) Diagnostic(index uint32) Diagnostic {
 }
 
 /*
-	Determines what compeltions are appropriate for the context
+	Determines what completions are appropriate for the context
 	the given code completion.
 
 	Parameter Results the code completion results to query

--- a/clang/comment_gen.go
+++ b/clang/comment_gen.go
@@ -1,10 +1,10 @@
 package clang
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 
-// A comment AST node.
+// A parsed comment.
 type Comment struct {
 	c C.CXComment
 }

--- a/clang/commentinlinecommandrenderkind_gen.go
+++ b/clang/commentinlinecommandrenderkind_gen.go
@@ -1,6 +1,6 @@
 package clang
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"

--- a/clang/commentkind_gen.go
+++ b/clang/commentkind_gen.go
@@ -1,6 +1,6 @@
 package clang
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"

--- a/clang/commentparampassdirection_gen.go
+++ b/clang/commentparampassdirection_gen.go
@@ -1,6 +1,6 @@
 package clang
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"

--- a/clang/compilecommand_gen.go
+++ b/clang/compilecommand_gen.go
@@ -17,6 +17,14 @@ func (cc CompileCommand) Directory() string {
 	return o.String()
 }
 
+// Get the filename associated with the CompileCommand.
+func (cc CompileCommand) Filename() string {
+	o := cxstring{C.clang_CompileCommand_getFilename(cc.c)}
+	defer o.Dispose()
+
+	return o.String()
+}
+
 // Get the number of arguments in the compiler invocation.
 func (cc CompileCommand) NumArgs() uint32 {
 	return uint32(C.clang_CompileCommand_getNumArgs(cc.c))

--- a/clang/cursor_gen.go
+++ b/clang/cursor_gen.go
@@ -1,5 +1,6 @@
 package clang
 
+// #include "./clang-c/Documentation.h"
 // #include "./clang-c/Index.h"
 // #include "go-clang.h"
 import "C"
@@ -28,6 +29,11 @@ import (
 */
 type Cursor struct {
 	c C.CXCursor
+}
+
+// Given a cursor that represents a documentable entity (e.g., declaration), return the associated parsed comment as a CXComment_FullComment AST node.
+func (c Cursor) ParsedComment() Comment {
+	return Comment{C.clang_Cursor_getParsedComment(c.c)}
 }
 
 // Retrieve the NULL cursor, which represents no entity.
@@ -59,9 +65,31 @@ func (c Cursor) Kind() CursorKind {
 	return CursorKind(C.clang_getCursorKind(c.c))
 }
 
+// Determine whether the given cursor has any attributes.
+func (c Cursor) HasAttrs() bool {
+	o := C.clang_Cursor_hasAttrs(c.c)
+
+	return o != C.uint(0)
+}
+
 // Determine the linkage of the entity referred to by a given cursor.
 func (c Cursor) Linkage() LinkageKind {
 	return LinkageKind(C.clang_getCursorLinkage(c.c))
+}
+
+/*
+	Describe the visibility of the entity referred to by a cursor.
+
+	This returns the default visibility if not explicitly specified by
+	a visibility attribute. The default visibility may be changed by
+	commandline arguments.
+
+	Parameter cursor The cursor to query.
+
+	Returns The visibility of the cursor.
+*/
+func (c Cursor) Visibility() VisibilityKind {
+	return VisibilityKind(C.clang_getCursorVisibility(c.c))
 }
 
 /*
@@ -103,7 +131,7 @@ func (c Cursor) TranslationUnit() TranslationUnit {
 	void C::f() { }
 	\endcode
 
-	In the out-of-line definition of C::f, the semantic parent is the
+	In the out-of-line definition of C::f, the semantic parent is
 	the class C, of which this function is a member. The lexical parent is
 	the place where the declaration actually occurs in the source code; in this
 	case, the definition occurs in the translation unit. In general, the
@@ -140,7 +168,7 @@ func (c Cursor) SemanticParent() Cursor {
 	void C::f() { }
 	\endcode
 
-	In the out-of-line definition of C::f, the semantic parent is the
+	In the out-of-line definition of C::f, the semantic parent is
 	the class C, of which this function is a member. The lexical parent is
 	the place where the declaration actually occurs in the source code; in this
 	case, the definition occurs in the translation unit. In general, the
@@ -252,7 +280,7 @@ func (c Cursor) Location() SourceLocation {
 
 	The extent of a cursor starts with the file/line/column pointing at the
 	first character within the source construct that the cursor refers to and
-	ends with the last character withinin that source construct. For a
+	ends with the last character within that source construct. For a
 	declaration, the extent covers the declaration itself. For a reference,
 	the extent covers the location of the reference (e.g., where the referenced
 	entity was actually used).
@@ -341,6 +369,131 @@ func (c Cursor) Argument(i uint32) Cursor {
 	return Cursor{C.clang_Cursor_getArgument(c.c, C.uint(i))}
 }
 
+/*
+	Returns the number of template args of a function decl representing a
+	template specialization.
+
+	If the argument cursor cannot be converted into a template function
+	declaration, -1 is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	The value 3 would be returned from this call.
+*/
+func (c Cursor) NumTemplateArguments() int32 {
+	return int32(C.clang_Cursor_getNumTemplateArguments(c.c))
+}
+
+/*
+	Retrieve the kind of the I'th template argument of the CXCursor C.
+
+	If the argument CXCursor does not represent a FunctionDecl, an invalid
+	template argument kind is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+	respectively.
+*/
+func (c Cursor) TemplateArgumentKind(i uint32) TemplateArgumentKind {
+	return TemplateArgumentKind(C.clang_Cursor_getTemplateArgumentKind(c.c, C.uint(i)))
+}
+
+/*
+	Retrieve a CXType representing the type of a TemplateArgument of a
+	function decl representing a template specialization.
+
+	If the argument CXCursor does not represent a FunctionDecl whose I'th
+	template argument has a kind of CXTemplateArgKind_Integral, an invalid type
+	is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	If called with I = 0, "float", will be returned.
+	Invalid types will be returned for I == 1 or 2.
+*/
+func (c Cursor) TemplateArgumentType(i uint32) Type {
+	return Type{C.clang_Cursor_getTemplateArgumentType(c.c, C.uint(i))}
+}
+
+/*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as a signed long long.
+
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl or whose I'th template argument is not an integral value.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	If called with I = 1 or 2, -7 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*/
+func (c Cursor) TemplateArgumentValue(i uint32) int64 {
+	return int64(C.clang_Cursor_getTemplateArgumentValue(c.c, C.uint(i)))
+}
+
+/*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as an unsigned long long.
+
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl or whose I'th template argument is not an integral value.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, 2147483649, true>();
+
+	If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*/
+func (c Cursor) TemplateArgumentUnsignedValue(i uint32) uint64 {
+	return uint64(C.clang_Cursor_getTemplateArgumentUnsignedValue(c.c, C.uint(i)))
+}
+
+// Determine whether a CXCursor that is a macro, is function like.
+func (c Cursor) IsMacroFunctionLike() bool {
+	o := C.clang_Cursor_isMacroFunctionLike(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine whether a CXCursor that is a macro, is a builtin one.
+func (c Cursor) IsMacroBuiltin() bool {
+	o := C.clang_Cursor_isMacroBuiltin(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine whether a CXCursor that is a function declaration, is an inline declaration.
+func (c Cursor) IsFunctionInlined() bool {
+	o := C.clang_Cursor_isFunctionInlined(c.c)
+
+	return o != C.uint(0)
+}
+
 // Returns the Objective-C type encoding for the specified declaration.
 func (c Cursor) DeclObjCTypeEncoding() string {
 	o := cxstring{C.clang_getDeclObjCTypeEncoding(c.c)}
@@ -350,12 +503,36 @@ func (c Cursor) DeclObjCTypeEncoding() string {
 }
 
 /*
-	Retrieve the result type associated with a given cursor.
+	Retrieve the return type associated with a given cursor.
 
 	This only returns a valid type if the cursor refers to a function or method.
 */
 func (c Cursor) ResultType() Type {
 	return Type{C.clang_getCursorResultType(c.c)}
+}
+
+/*
+	Return the offset of the field represented by the Cursor.
+
+	If the cursor is not a field declaration, -1 is returned.
+	If the cursor semantic parent is not a record field declaration,
+	CXTypeLayoutError_Invalid is returned.
+	If the field's type declaration is an incomplete type,
+	CXTypeLayoutError_Incomplete is returned.
+	If the field's type declaration is a dependent type,
+	CXTypeLayoutError_Dependent is returned.
+	If the field's name S is not found,
+	CXTypeLayoutError_InvalidFieldName is returned.
+*/
+func (c Cursor) OffsetOfField() int64 {
+	return int64(C.clang_Cursor_getOffsetOfField(c.c))
+}
+
+// Determine whether the given cursor represents an anonymous record declaration.
+func (c Cursor) IsAnonymous() bool {
+	o := C.clang_Cursor_isAnonymous(c.c)
+
+	return o != C.uint(0)
 }
 
 // Returns non-zero if the cursor specifies a Record member that is a bitfield.
@@ -381,6 +558,16 @@ func (c Cursor) IsVirtualBase() bool {
 */
 func (c Cursor) AccessSpecifier() AccessSpecifier {
 	return AccessSpecifier(C.clang_getCXXAccessSpecifier(c.c))
+}
+
+/*
+	Returns the storage class for a function or variable declaration.
+
+	If the passed in Cursor is not a function or variable declaration,
+	CX_SC_Invalid is returned else the storage class.
+*/
+func (c Cursor) StorageClass() StorageClass {
+	return StorageClass(C.clang_Cursor_getStorageClass(c.c))
 }
 
 /*
@@ -449,8 +636,8 @@ func (c Cursor) Spelling() string {
 /*
 	Retrieve a range for a piece that forms the cursors spelling name.
 	Most of the times there is only one range for the complete spelling but for
-	objc methods and objc message expressions, there are multiple pieces for each
-	selector identifier.
+	Objective-C methods and Objective-C message expressions, there are multiple
+	pieces for each selector identifier.
 
 	Parameter pieceIndex the index of the spelling name piece. If this is greater
 	than the actual number of pieces, it will return a NULL (invalid) range.
@@ -558,13 +745,13 @@ func (c Cursor) CanonicalCursor() Cursor {
 }
 
 /*
-	If the cursor points to a selector identifier in a objc method or
-	message expression, this returns the selector index.
+	If the cursor points to a selector identifier in an Objective-C
+	method or message expression, this returns the selector index.
 
 	After getting a cursor with #clang_getCursor, this can be called to
 	determine if the location points to a selector identifier.
 
-	Returns The selector index if the cursor is an objc method or message
+	Returns The selector index if the cursor is an Objective-C method or message
 	expression and the cursor is pointing to a selector identifier, or -1
 	otherwise.
 */
@@ -573,12 +760,12 @@ func (c Cursor) SelectorIndex() int32 {
 }
 
 /*
-	Given a cursor pointing to a C++ method call or an ObjC message,
-	returns non-zero if the method/message is "dynamic", meaning:
+	Given a cursor pointing to a C++ method call or an Objective-C
+	message, returns non-zero if the method/message is "dynamic", meaning:
 
 	For a C++ method: the call is virtual.
-	For an ObjC message: the receiver is an object instance, not 'super' or a
-	specific class.
+	For an Objective-C message: the receiver is an object instance, not 'super'
+	or a specific class.
 
 	If the method/message is "static" or the cursor does not point to a
 	method/message, it will return zero.
@@ -589,7 +776,7 @@ func (c Cursor) IsDynamicCall() bool {
 	return o != C.int(0)
 }
 
-// Given a cursor pointing to an ObjC message, returns the CXType of the receiver.
+// Given a cursor pointing to an Objective-C message, returns the CXType of the receiver.
 func (c Cursor) ReceiverType() Type {
 	return Type{C.clang_Cursor_getReceiverType(c.c)}
 }
@@ -605,12 +792,12 @@ func (c Cursor) PropertyAttributes(reserved uint32) uint32 {
 	return uint32(C.clang_Cursor_getObjCPropertyAttributes(c.c, C.uint(reserved)))
 }
 
-// Given a cursor that represents an ObjC method or parameter declaration, return the associated ObjC qualifiers for the return type or the parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
+// Given a cursor that represents an Objective-C method or parameter declaration, return the associated Objective-C qualifiers for the return type or the parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
 func (c Cursor) DeclQualifiers() uint32 {
 	return uint32(C.clang_Cursor_getObjCDeclQualifiers(c.c))
 }
 
-// Given a cursor that represents an ObjC method or property declaration, return non-zero if the declaration was affected by "@optional". Returns zero if the cursor is not such a declaration or it is "@required".
+// Given a cursor that represents an Objective-C method or property declaration, return non-zero if the declaration was affected by "@optional". Returns zero if the cursor is not such a declaration or it is "@required".
 func (c Cursor) IsObjCOptional() bool {
 	o := C.clang_Cursor_isObjCOptional(c.c)
 
@@ -645,14 +832,71 @@ func (c Cursor) BriefCommentText() string {
 	return o.String()
 }
 
-// Given a cursor that represents a documentable entity (e.g., declaration), return the associated parsed comment as a CXComment_FullComment AST node.
-func (c Cursor) ParsedComment() Comment {
-	return Comment{C.clang_Cursor_getParsedComment(c.c)}
+// Retrieve the CXString representing the mangled name of the cursor.
+func (c Cursor) Mangling() string {
+	o := cxstring{C.clang_Cursor_getMangling(c.c)}
+	defer o.Dispose()
+
+	return o.String()
+}
+
+// Retrieve the CXStrings representing the mangled symbols of the C++ constructor or destructor at the cursor.
+func (c Cursor) Manglings() *StringSet {
+	o := C.clang_Cursor_getCXXManglings(c.c)
+
+	var gop_o *StringSet
+	if o != nil {
+		gop_o = &StringSet{*o}
+	}
+
+	return gop_o
 }
 
 // Given a CXCursor_ModuleImportDecl cursor, return the associated module.
 func (c Cursor) Module() Module {
 	return Module{C.clang_Cursor_getModule(c.c)}
+}
+
+// Determine if a C++ constructor is a converting constructor.
+func (c Cursor) CXXConstructor_IsConvertingConstructor() bool {
+	o := C.clang_CXXConstructor_isConvertingConstructor(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ constructor is a copy constructor.
+func (c Cursor) CXXConstructor_IsCopyConstructor() bool {
+	o := C.clang_CXXConstructor_isCopyConstructor(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ constructor is the default constructor.
+func (c Cursor) CXXConstructor_IsDefaultConstructor() bool {
+	o := C.clang_CXXConstructor_isDefaultConstructor(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ constructor is a move constructor.
+func (c Cursor) CXXConstructor_IsMoveConstructor() bool {
+	o := C.clang_CXXConstructor_isMoveConstructor(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ field is declared 'mutable'.
+func (c Cursor) CXXField_IsMutable() bool {
+	o := C.clang_CXXField_isMutable(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ method is declared '= default'.
+func (c Cursor) CXXMethod_IsDefaulted() bool {
+	o := C.clang_CXXMethod_isDefaulted(c.c)
+
+	return o != C.uint(0)
 }
 
 // Determine if a C++ member function or member function template is pure virtual.
@@ -672,6 +916,13 @@ func (c Cursor) CXXMethod_IsStatic() bool {
 // Determine if a C++ member function or member function template is explicitly declared 'virtual' or if it overrides a virtual method from one of the base classes.
 func (c Cursor) CXXMethod_IsVirtual() bool {
 	o := C.clang_CXXMethod_isVirtual(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ member function or member function template is declared 'const'.
+func (c Cursor) CXXMethod_IsConst() bool {
+	o := C.clang_CXXMethod_isConst(c.c)
 
 	return o != C.uint(0)
 }
@@ -777,6 +1028,11 @@ func (c Cursor) DefinitionSpellingAndExtent() (string, string, uint32, uint32, u
 */
 func (c Cursor) CompletionString() CompletionString {
 	return CompletionString{C.clang_getCursorCompletionString(c.c)}
+}
+
+// If cursor is a statement declaration tries to evaluate the statement and if its variable, tries to evaluate its initializer, into its corresponding type.
+func (c Cursor) Evaluate() EvalResult {
+	return EvalResult{C.clang_Cursor_Evaluate(c.c)}
 }
 
 /*

--- a/clang/cursorkind_gen.go
+++ b/clang/cursorkind_gen.go
@@ -54,7 +54,7 @@ const (
 	Cursor_ObjCImplementationDecl = C.CXCursor_ObjCImplementationDecl
 	// An Objective-C \@implementation for a category.
 	Cursor_ObjCCategoryImplDecl = C.CXCursor_ObjCCategoryImplDecl
-	// A typedef
+	// A typedef.
 	Cursor_TypedefDecl = C.CXCursor_TypedefDecl
 	// A C++ class method.
 	Cursor_CXXMethod = C.CXCursor_CXXMethod
@@ -225,7 +225,7 @@ const (
 		expression is not reported.
 	*/
 	Cursor_UnexposedExpr = C.CXCursor_UnexposedExpr
-	// An expression that refers to some value declaration, such as a function, varible, or enumerator.
+	// An expression that refers to some value declaration, such as a function, variable, or enumerator.
 	Cursor_DeclRefExpr = C.CXCursor_DeclRefExpr
 	// An expression that refers to a member of a struct, union, class, Objective-C class, etc.
 	Cursor_MemberRefExpr = C.CXCursor_MemberRefExpr
@@ -325,7 +325,7 @@ const (
 	Cursor_CXXNewExpr = C.CXCursor_CXXNewExpr
 	// A delete expression for memory deallocation and destructor calls, e.g. "delete[] pArray".
 	Cursor_CXXDeleteExpr = C.CXCursor_CXXDeleteExpr
-	// A unary expression.
+	// A unary expression. (noexcept, sizeof, or other traits)
 	Cursor_UnaryExpr = C.CXCursor_UnaryExpr
 	// An Objective-C string literal i.e. @"foo".
 	Cursor_ObjCStringLiteral = C.CXCursor_ObjCStringLiteral
@@ -374,11 +374,15 @@ const (
 	Cursor_LambdaExpr     = C.CXCursor_LambdaExpr
 	// Objective-c Boolean Literal.
 	Cursor_ObjCBoolLiteralExpr = C.CXCursor_ObjCBoolLiteralExpr
-	// Represents the "self" expression in a ObjC method.
+	// Represents the "self" expression in an Objective-C method.
 	Cursor_ObjCSelfExpr = C.CXCursor_ObjCSelfExpr
-	// Represents the "self" expression in a ObjC method.
+	// OpenMP 4.0 [2.4, Array Section].
+	Cursor_OMPArraySectionExpr = C.CXCursor_OMPArraySectionExpr
+	// Represents an @available(...) check.
+	Cursor_ObjCAvailabilityCheckExpr = C.CXCursor_ObjCAvailabilityCheckExpr
+	// Represents an @available(...) check.
 	Cursor_LastExpr = C.CXCursor_LastExpr
-	// Represents the "self" expression in a ObjC method.
+	// Represents an @available(...) check.
 	Cursor_FirstStmt = C.CXCursor_FirstStmt
 	/*
 		A statement whose specific kind is not exposed via this
@@ -466,7 +470,7 @@ const (
 	// A MS inline assembly statement extension.
 	Cursor_MSAsmStmt = C.CXCursor_MSAsmStmt
 	/*
-		The null satement ";": C99 6.8.3p3.
+		The null statement ";": C99 6.8.3p3.
 
 		This cursor kind is used to describe the null statement.
 	*/
@@ -475,7 +479,81 @@ const (
 	Cursor_DeclStmt = C.CXCursor_DeclStmt
 	// OpenMP parallel directive.
 	Cursor_OMPParallelDirective = C.CXCursor_OMPParallelDirective
-	// OpenMP parallel directive.
+	// OpenMP SIMD directive.
+	Cursor_OMPSimdDirective = C.CXCursor_OMPSimdDirective
+	// OpenMP for directive.
+	Cursor_OMPForDirective = C.CXCursor_OMPForDirective
+	// OpenMP sections directive.
+	Cursor_OMPSectionsDirective = C.CXCursor_OMPSectionsDirective
+	// OpenMP section directive.
+	Cursor_OMPSectionDirective = C.CXCursor_OMPSectionDirective
+	// OpenMP single directive.
+	Cursor_OMPSingleDirective = C.CXCursor_OMPSingleDirective
+	// OpenMP parallel for directive.
+	Cursor_OMPParallelForDirective = C.CXCursor_OMPParallelForDirective
+	// OpenMP parallel sections directive.
+	Cursor_OMPParallelSectionsDirective = C.CXCursor_OMPParallelSectionsDirective
+	// OpenMP task directive.
+	Cursor_OMPTaskDirective = C.CXCursor_OMPTaskDirective
+	// OpenMP master directive.
+	Cursor_OMPMasterDirective = C.CXCursor_OMPMasterDirective
+	// OpenMP critical directive.
+	Cursor_OMPCriticalDirective = C.CXCursor_OMPCriticalDirective
+	// OpenMP taskyield directive.
+	Cursor_OMPTaskyieldDirective = C.CXCursor_OMPTaskyieldDirective
+	// OpenMP barrier directive.
+	Cursor_OMPBarrierDirective = C.CXCursor_OMPBarrierDirective
+	// OpenMP taskwait directive.
+	Cursor_OMPTaskwaitDirective = C.CXCursor_OMPTaskwaitDirective
+	// OpenMP flush directive.
+	Cursor_OMPFlushDirective = C.CXCursor_OMPFlushDirective
+	// Windows Structured Exception Handling's leave statement.
+	Cursor_SEHLeaveStmt = C.CXCursor_SEHLeaveStmt
+	// OpenMP ordered directive.
+	Cursor_OMPOrderedDirective = C.CXCursor_OMPOrderedDirective
+	// OpenMP atomic directive.
+	Cursor_OMPAtomicDirective = C.CXCursor_OMPAtomicDirective
+	// OpenMP for SIMD directive.
+	Cursor_OMPForSimdDirective = C.CXCursor_OMPForSimdDirective
+	// OpenMP parallel for SIMD directive.
+	Cursor_OMPParallelForSimdDirective = C.CXCursor_OMPParallelForSimdDirective
+	// OpenMP target directive.
+	Cursor_OMPTargetDirective = C.CXCursor_OMPTargetDirective
+	// OpenMP teams directive.
+	Cursor_OMPTeamsDirective = C.CXCursor_OMPTeamsDirective
+	// OpenMP taskgroup directive.
+	Cursor_OMPTaskgroupDirective = C.CXCursor_OMPTaskgroupDirective
+	// OpenMP cancellation point directive.
+	Cursor_OMPCancellationPointDirective = C.CXCursor_OMPCancellationPointDirective
+	// OpenMP cancel directive.
+	Cursor_OMPCancelDirective = C.CXCursor_OMPCancelDirective
+	// OpenMP target data directive.
+	Cursor_OMPTargetDataDirective = C.CXCursor_OMPTargetDataDirective
+	// OpenMP taskloop directive.
+	Cursor_OMPTaskLoopDirective = C.CXCursor_OMPTaskLoopDirective
+	// OpenMP taskloop simd directive.
+	Cursor_OMPTaskLoopSimdDirective = C.CXCursor_OMPTaskLoopSimdDirective
+	// OpenMP distribute directive.
+	Cursor_OMPDistributeDirective = C.CXCursor_OMPDistributeDirective
+	// OpenMP target enter data directive.
+	Cursor_OMPTargetEnterDataDirective = C.CXCursor_OMPTargetEnterDataDirective
+	// OpenMP target exit data directive.
+	Cursor_OMPTargetExitDataDirective = C.CXCursor_OMPTargetExitDataDirective
+	// OpenMP target parallel directive.
+	Cursor_OMPTargetParallelDirective = C.CXCursor_OMPTargetParallelDirective
+	// OpenMP target parallel for directive.
+	Cursor_OMPTargetParallelForDirective = C.CXCursor_OMPTargetParallelForDirective
+	// OpenMP target update directive.
+	Cursor_OMPTargetUpdateDirective = C.CXCursor_OMPTargetUpdateDirective
+	// OpenMP distribute parallel for directive.
+	Cursor_OMPDistributeParallelForDirective = C.CXCursor_OMPDistributeParallelForDirective
+	// OpenMP distribute parallel for simd directive.
+	Cursor_OMPDistributeParallelForSimdDirective = C.CXCursor_OMPDistributeParallelForSimdDirective
+	// OpenMP distribute simd directive.
+	Cursor_OMPDistributeSimdDirective = C.CXCursor_OMPDistributeSimdDirective
+	// OpenMP target parallel for simd directive.
+	Cursor_OMPTargetParallelForSimdDirective = C.CXCursor_OMPTargetParallelForSimdDirective
+	// OpenMP target parallel for simd directive.
 	Cursor_LastStmt = C.CXCursor_LastStmt
 	/*
 		Cursor that represents the translation unit itself.
@@ -510,6 +588,28 @@ const (
 	// An attribute whose specific kind is not exposed via this interface.
 	Cursor_PackedAttr = C.CXCursor_PackedAttr
 	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_PureAttr = C.CXCursor_PureAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_ConstAttr = C.CXCursor_ConstAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_NoDuplicateAttr = C.CXCursor_NoDuplicateAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAConstantAttr = C.CXCursor_CUDAConstantAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDADeviceAttr = C.CXCursor_CUDADeviceAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAGlobalAttr = C.CXCursor_CUDAGlobalAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAHostAttr = C.CXCursor_CUDAHostAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDASharedAttr = C.CXCursor_CUDASharedAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_VisibilityAttr = C.CXCursor_VisibilityAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_DLLExport = C.CXCursor_DLLExport
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_DLLImport = C.CXCursor_DLLImport
+	// An attribute whose specific kind is not exposed via this interface.
 	Cursor_LastAttr = C.CXCursor_LastAttr
 	// An attribute whose specific kind is not exposed via this interface.
 	Cursor_PreprocessingDirective = C.CXCursor_PreprocessingDirective
@@ -528,9 +628,15 @@ const (
 	// A module import declaration.
 	Cursor_ModuleImportDecl = C.CXCursor_ModuleImportDecl
 	// A module import declaration.
+	Cursor_TypeAliasTemplateDecl = C.CXCursor_TypeAliasTemplateDecl
+	// A static_assert or _Static_assert node
+	Cursor_StaticAssert = C.CXCursor_StaticAssert
+	// A static_assert or _Static_assert node
 	Cursor_FirstExtraDecl = C.CXCursor_FirstExtraDecl
-	// A module import declaration.
+	// A static_assert or _Static_assert node
 	Cursor_LastExtraDecl = C.CXCursor_LastExtraDecl
+	// A code completion overload candidate.
+	Cursor_OverloadCandidate = C.CXCursor_OverloadCandidate
 )
 
 // Determine whether the given cursor kind represents a declaration.

--- a/clang/declqualifierkind_gen.go
+++ b/clang/declqualifierkind_gen.go
@@ -5,7 +5,7 @@ package clang
 import "C"
 import "fmt"
 
-// 'Qualifiers' written next to the return and parameter types in ObjC method declarations.
+// 'Qualifiers' written next to the return and parameter types in Objective-C method declarations.
 type DeclQualifierKind uint32
 
 const (

--- a/clang/errorcode_gen.go
+++ b/clang/errorcode_gen.go
@@ -1,0 +1,53 @@
+package clang
+
+// #include "./clang-c/CXErrorCode.h"
+// #include "go-clang.h"
+import "C"
+import "fmt"
+
+/*
+	Error codes returned by libclang routines.
+
+	Zero (CXError_Success) is the only error code indicating success. Other
+	error codes, including not yet assigned non-zero values, indicate errors.
+*/
+type ErrorCode uint32
+
+const (
+	// No error.
+	Error_Success ErrorCode = C.CXError_Success
+	/*
+		A generic error code, no further details are available.
+
+		Errors of this kind can get their own specific error codes in future
+		libclang versions.
+	*/
+	Error_Failure = C.CXError_Failure
+	// libclang crashed while performing the requested operation.
+	Error_Crashed = C.CXError_Crashed
+	// The function detected that the arguments violate the function contract.
+	Error_InvalidArguments = C.CXError_InvalidArguments
+	// An AST deserialization error has occurred.
+	Error_ASTReadError = C.CXError_ASTReadError
+)
+
+func (ec ErrorCode) Spelling() string {
+	switch ec {
+	case Error_Success:
+		return "Error=Success"
+	case Error_Failure:
+		return "Error=Failure"
+	case Error_Crashed:
+		return "Error=Crashed"
+	case Error_InvalidArguments:
+		return "Error=InvalidArguments"
+	case Error_ASTReadError:
+		return "Error=ASTReadError"
+	}
+
+	return fmt.Sprintf("ErrorCode unkown %d", int(ec))
+}
+
+func (ec ErrorCode) String() string {
+	return ec.Spelling()
+}

--- a/clang/evalresult_gen.go
+++ b/clang/evalresult_gen.go
@@ -1,0 +1,35 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+
+// Evaluation result of a cursor
+type EvalResult struct {
+	c C.CXEvalResult
+}
+
+// Returns the kind of the evaluated result.
+func (er EvalResult) Kind() EvalResultKind {
+	return EvalResultKind(C.clang_EvalResult_getKind(er.c))
+}
+
+// Returns the evaluation result as integer if the kind is Int.
+func (er EvalResult) AsInt() int32 {
+	return int32(C.clang_EvalResult_getAsInt(er.c))
+}
+
+// Returns the evaluation result as double if the kind is double.
+func (er EvalResult) AsDouble() float64 {
+	return float64(C.clang_EvalResult_getAsDouble(er.c))
+}
+
+// Returns the evaluation result as a constant string if the kind is other than Int or float. User must not free this pointer, instead call clang_EvalResult_dispose on the CXEvalResult returned by clang_Cursor_Evaluate.
+func (er EvalResult) AsStr() string {
+	return C.GoString(C.clang_EvalResult_getAsStr(er.c))
+}
+
+// Disposes the created Eval memory.
+func (er EvalResult) Dispose() {
+	C.clang_EvalResult_dispose(er.c)
+}

--- a/clang/evalresultkind_gen.go
+++ b/clang/evalresultkind_gen.go
@@ -1,0 +1,43 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+import "fmt"
+
+type EvalResultKind uint32
+
+const (
+	Eval_Int            EvalResultKind = C.CXEval_Int
+	Eval_Float                         = C.CXEval_Float
+	Eval_ObjCStrLiteral                = C.CXEval_ObjCStrLiteral
+	Eval_StrLiteral                    = C.CXEval_StrLiteral
+	Eval_CFStr                         = C.CXEval_CFStr
+	Eval_Other                         = C.CXEval_Other
+	Eval_UnExposed                     = C.CXEval_UnExposed
+)
+
+func (erk EvalResultKind) Spelling() string {
+	switch erk {
+	case Eval_Int:
+		return "Eval=Int"
+	case Eval_Float:
+		return "Eval=Float"
+	case Eval_ObjCStrLiteral:
+		return "Eval=ObjCStrLiteral"
+	case Eval_StrLiteral:
+		return "Eval=StrLiteral"
+	case Eval_CFStr:
+		return "Eval=CFStr"
+	case Eval_Other:
+		return "Eval=Other"
+	case Eval_UnExposed:
+		return "Eval=UnExposed"
+	}
+
+	return fmt.Sprintf("EvalResultKind unkown %d", int(erk))
+}
+
+func (erk EvalResultKind) String() string {
+	return erk.Spelling()
+}

--- a/clang/file_gen.go
+++ b/clang/file_gen.go
@@ -38,3 +38,10 @@ func (f File) UniqueID() (FileUniqueID, int32) {
 
 	return outID, o
 }
+
+// Returns non-zero if the file1 and file2 point to the same file, or they are both NULL.
+func (f File) IsEqual(file2 File) bool {
+	o := C.clang_File_isEqual(f.c, file2.c)
+
+	return o != C.int(0)
+}

--- a/clang/idxdeclinfo_gen.go
+++ b/clang/idxdeclinfo_gen.go
@@ -149,7 +149,7 @@ func (idi IdxDeclInfo) DeclAsContainer() *IdxContainerInfo {
 	return gop_o
 }
 
-// Whether the declaration exists in code or was created implicitly by the compiler, e.g. implicit objc methods for properties.
+// Whether the declaration exists in code or was created implicitly by the compiler, e.g. implicit Objective-C methods for properties.
 func (idi IdxDeclInfo) IsImplicit() bool {
 	o := idi.c.isImplicit
 

--- a/clang/idxentityrefkind_gen.go
+++ b/clang/idxentityrefkind_gen.go
@@ -11,7 +11,7 @@ type IdxEntityRefKind uint32
 const (
 	// The entity is referenced directly in user's code.
 	IdxEntityRef_Direct IdxEntityRefKind = C.CXIdxEntityRef_Direct
-	// An implicit reference, e.g. a reference of an ObjC method via the dot syntax.
+	// An implicit reference, e.g. a reference of an Objective-C method via the dot syntax.
 	IdxEntityRef_Implicit = C.CXIdxEntityRef_Implicit
 )
 

--- a/clang/index_gen.go
+++ b/clang/index_gen.go
@@ -154,7 +154,7 @@ func (i Index) TranslationUnitFromSourceFile(sourceFilename string, clangCommand
 	return TranslationUnit{C.clang_createTranslationUnitFromSourceFile(i.c, c_sourceFilename, C.int(len(clangCommandLineArgs)), cp_clangCommandLineArgs, C.uint(len(unsavedFiles)), cp_unsavedFiles)}
 }
 
-// Create a translation unit from an AST file (-emit-ast).
+// Same as clang_createTranslationUnit2, but returns the CXTranslationUnit instead of an error code. In case of an error this routine returns a NULL CXTranslationUnit, without further detailed error codes.
 func (i Index) TranslationUnit(astFilename string) TranslationUnit {
 	c_astFilename := C.CString(astFilename)
 	defer C.free(unsafe.Pointer(c_astFilename))
@@ -163,47 +163,21 @@ func (i Index) TranslationUnit(astFilename string) TranslationUnit {
 }
 
 /*
-	Parse the given source file and the translation unit corresponding
-	to that file.
+	Create a translation unit from an AST file (-emit-ast).
 
-	This routine is the main entry point for the Clang C API, providing the
-	ability to parse a source file into a translation unit that can then be
-	queried by other functions in the API. This routine accepts a set of
-	command-line arguments so that the compilation can be configured in the same
-	way that the compiler is configured on the command line.
+	\param[out] out_TU A non-NULL pointer to store the created
+	CXTranslationUnit.
 
-	Parameter CIdx The index object with which the translation unit will be
-	associated.
-
-	Parameter source_filename The name of the source file to load, or NULL if the
-	source file is included in \p command_line_args.
-
-	Parameter command_line_args The command-line arguments that would be
-	passed to the clang executable if it were being invoked out-of-process.
-	These command-line options will be parsed and will affect how the translation
-	unit is parsed. Note that the following options are ignored: '-c',
-	'-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
-
-	Parameter num_command_line_args The number of command-line arguments in
-	\p command_line_args.
-
-	Parameter unsaved_files the files that have not yet been saved to disk
-	but may be required for parsing, including the contents of
-	those files. The contents and name of these files (as specified by
-	CXUnsavedFile) are copied when necessary, so the client only needs to
-	guarantee their validity until the call to this function returns.
-
-	Parameter num_unsaved_files the number of unsaved file entries in \p
-	unsaved_files.
-
-	Parameter options A bitmask of options that affects how the translation unit
-	is managed but not its compilation. This should be a bitwise OR of the
-	CXTranslationUnit_XXX flags.
-
-	Returns A new translation unit describing the parsed code and containing
-	any diagnostics produced by the compiler. If there is a failure from which
-	the compiler cannot recover, returns NULL.
+	Returns Zero on success, otherwise returns an error code.
 */
+func (i Index) TranslationUnit2(astFilename string, outTU *TranslationUnit) ErrorCode {
+	c_astFilename := C.CString(astFilename)
+	defer C.free(unsafe.Pointer(c_astFilename))
+
+	return ErrorCode(C.clang_createTranslationUnit2(i.c, c_astFilename, &outTU.c))
+}
+
+// Same as clang_parseTranslationUnit2, but returns the CXTranslationUnit instead of an error code. In case of an error this routine returns a NULL CXTranslationUnit, without further detailed error codes.
 func (i Index) ParseTranslationUnit(sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, options uint32) TranslationUnit {
 	ca_commandLineArgs := make([]*C.char, len(commandLineArgs))
 	var cp_commandLineArgs **C.char
@@ -222,6 +196,91 @@ func (i Index) ParseTranslationUnit(sourceFilename string, commandLineArgs []str
 	defer C.free(unsafe.Pointer(c_sourceFilename))
 
 	return TranslationUnit{C.clang_parseTranslationUnit(i.c, c_sourceFilename, cp_commandLineArgs, C.int(len(commandLineArgs)), cp_unsavedFiles, C.uint(len(unsavedFiles)), C.uint(options))}
+}
+
+/*
+	Parse the given source file and the translation unit corresponding
+	to that file.
+
+	This routine is the main entry point for the Clang C API, providing the
+	ability to parse a source file into a translation unit that can then be
+	queried by other functions in the API. This routine accepts a set of
+	command-line arguments so that the compilation can be configured in the same
+	way that the compiler is configured on the command line.
+
+	Parameter CIdx The index object with which the translation unit will be
+	associated.
+
+	Parameter source_filename The name of the source file to load, or NULL if the
+	source file is included in command_line_args.
+
+	Parameter command_line_args The command-line arguments that would be
+	passed to the clang executable if it were being invoked out-of-process.
+	These command-line options will be parsed and will affect how the translation
+	unit is parsed. Note that the following options are ignored: '-c',
+	'-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+
+	Parameter num_command_line_args The number of command-line arguments in
+	command_line_args.
+
+	Parameter unsaved_files the files that have not yet been saved to disk
+	but may be required for parsing, including the contents of
+	those files. The contents and name of these files (as specified by
+	CXUnsavedFile) are copied when necessary, so the client only needs to
+	guarantee their validity until the call to this function returns.
+
+	Parameter num_unsaved_files the number of unsaved file entries in \p
+	unsaved_files.
+
+	Parameter options A bitmask of options that affects how the translation unit
+	is managed but not its compilation. This should be a bitwise OR of the
+	CXTranslationUnit_XXX flags.
+
+	\param[out] out_TU A non-NULL pointer to store the created
+	CXTranslationUnit, describing the parsed code and containing any
+	diagnostics produced by the compiler.
+
+	Returns Zero on success, otherwise returns an error code.
+*/
+func (i Index) ParseTranslationUnit2(sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, options uint32, outTU *TranslationUnit) ErrorCode {
+	ca_commandLineArgs := make([]*C.char, len(commandLineArgs))
+	var cp_commandLineArgs **C.char
+	if len(commandLineArgs) > 0 {
+		cp_commandLineArgs = &ca_commandLineArgs[0]
+	}
+	for i := range commandLineArgs {
+		ci_str := C.CString(commandLineArgs[i])
+		defer C.free(unsafe.Pointer(ci_str))
+		ca_commandLineArgs[i] = ci_str
+	}
+	gos_unsavedFiles := (*reflect.SliceHeader)(unsafe.Pointer(&unsavedFiles))
+	cp_unsavedFiles := (*C.struct_CXUnsavedFile)(unsafe.Pointer(gos_unsavedFiles.Data))
+
+	c_sourceFilename := C.CString(sourceFilename)
+	defer C.free(unsafe.Pointer(c_sourceFilename))
+
+	return ErrorCode(C.clang_parseTranslationUnit2(i.c, c_sourceFilename, cp_commandLineArgs, C.int(len(commandLineArgs)), cp_unsavedFiles, C.uint(len(unsavedFiles)), C.uint(options), &outTU.c))
+}
+
+// Same as clang_parseTranslationUnit2 but requires a full command line for command_line_args including argv[0]. This is useful if the standard library paths are relative to the binary.
+func (i Index) ParseTranslationUnit2FullArgv(sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, options uint32, outTU *TranslationUnit) ErrorCode {
+	ca_commandLineArgs := make([]*C.char, len(commandLineArgs))
+	var cp_commandLineArgs **C.char
+	if len(commandLineArgs) > 0 {
+		cp_commandLineArgs = &ca_commandLineArgs[0]
+	}
+	for i := range commandLineArgs {
+		ci_str := C.CString(commandLineArgs[i])
+		defer C.free(unsafe.Pointer(ci_str))
+		ca_commandLineArgs[i] = ci_str
+	}
+	gos_unsavedFiles := (*reflect.SliceHeader)(unsafe.Pointer(&unsavedFiles))
+	cp_unsavedFiles := (*C.struct_CXUnsavedFile)(unsafe.Pointer(gos_unsavedFiles.Data))
+
+	c_sourceFilename := C.CString(sourceFilename)
+	defer C.free(unsafe.Pointer(c_sourceFilename))
+
+	return ErrorCode(C.clang_parseTranslationUnit2FullArgv(i.c, c_sourceFilename, cp_commandLineArgs, C.int(len(commandLineArgs)), cp_unsavedFiles, C.uint(len(unsavedFiles)), C.uint(options), &outTU.c))
 }
 
 /*

--- a/clang/indexoptflags_gen.go
+++ b/clang/indexoptflags_gen.go
@@ -18,7 +18,7 @@ const (
 	IndexOpt_IndexImplicitTemplateInstantiations = C.CXIndexOpt_IndexImplicitTemplateInstantiations
 	// Suppress all compiler warnings when parsing for indexing.
 	IndexOpt_SuppressWarnings = C.CXIndexOpt_SuppressWarnings
-	// Skip a function/method body that was already parsed during an indexing session assosiated with a CXIndexAction object. Bodies in system headers are always skipped.
+	// Skip a function/method body that was already parsed during an indexing session associated with a CXIndexAction object. Bodies in system headers are always skipped.
 	IndexOpt_SkipParsedBodiesInSession = C.CXIndexOpt_SkipParsedBodiesInSession
 )
 

--- a/clang/module_gen.go
+++ b/clang/module_gen.go
@@ -51,3 +51,14 @@ func (m Module) FullName() string {
 
 	return o.String()
 }
+
+/*
+	Parameter Module a module object.
+
+	Returns non-zero if the module is a system one.
+*/
+func (m Module) IsSystem() bool {
+	o := C.clang_Module_isSystem(m.c)
+
+	return o != C.int(0)
+}

--- a/clang/modulemapdescriptor_gen.go
+++ b/clang/modulemapdescriptor_gen.go
@@ -1,0 +1,10 @@
+package clang
+
+// #include "./clang-c/BuildSystem.h"
+// #include "go-clang.h"
+import "C"
+
+// Object encapsulating information about a module.map file.
+type ModuleMapDescriptor struct {
+	c C.CXModuleMapDescriptor
+}

--- a/clang/namerefflags_gen.go
+++ b/clang/namerefflags_gen.go
@@ -18,7 +18,7 @@ const (
 		Non-contiguous names occur in Objective-C when a selector with two or more
 		parameters is used, or in C++ when using an operator:
 		\code
-		[object doSomething:here withValue:there]; // ObjC
+		[object doSomething:here withValue:there]; // Objective-C
 		return some_vector[1]; // C++
 		\endcode
 	*/

--- a/clang/platformavailability_gen.go
+++ b/clang/platformavailability_gen.go
@@ -18,7 +18,7 @@ func (pa PlatformAvailability) Dispose() {
 	A string that describes the platform for which this structure
 	provides availability information.
 
-	Possible values are "ios" or "macosx".
+	Possible values are "ios" or "macos".
 */
 func (pa PlatformAvailability) Platform() string {
 	o := cxstring{pa.c.Platform}

--- a/clang/propertyattrkind_gen.go
+++ b/clang/propertyattrkind_gen.go
@@ -22,6 +22,7 @@ const (
 	PropertyAttr_weak                               = C.CXObjCPropertyAttr_weak
 	PropertyAttr_strong                             = C.CXObjCPropertyAttr_strong
 	PropertyAttr_unsafe_unretained                  = C.CXObjCPropertyAttr_unsafe_unretained
+	PropertyAttr_class                              = C.CXObjCPropertyAttr_class
 )
 
 func (pak PropertyAttrKind) Spelling() string {
@@ -52,6 +53,8 @@ func (pak PropertyAttrKind) Spelling() string {
 		return "PropertyAttr=strong"
 	case PropertyAttr_unsafe_unretained:
 		return "PropertyAttr=unsafe_unretained"
+	case PropertyAttr_class:
+		return "PropertyAttr=class"
 	}
 
 	return fmt.Sprintf("PropertyAttrKind unkown %d", int(pak))

--- a/clang/sourcerangelist_gen.go
+++ b/clang/sourcerangelist_gen.go
@@ -1,0 +1,30 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Identifies an array of ranges.
+type SourceRangeList struct {
+	c C.CXSourceRangeList
+}
+
+// The number of ranges in the ranges array.
+func (srl SourceRangeList) Count() uint32 {
+	return uint32(srl.c.count)
+}
+
+// An array of CXSourceRanges.
+func (srl SourceRangeList) Ranges() []SourceRange {
+	var s []SourceRange
+	gos_s := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	gos_s.Cap = int(srl.c.count)
+	gos_s.Len = int(srl.c.count)
+	gos_s.Data = uintptr(unsafe.Pointer(srl.c.ranges))
+
+	return s
+}

--- a/clang/storageclass_gen.go
+++ b/clang/storageclass_gen.go
@@ -1,0 +1,47 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+import "fmt"
+
+// Represents the storage classes as declared in the source. CX_SC_Invalid was added for the case that the passed cursor in not a declaration.
+type StorageClass uint32
+
+const (
+	SC_Invalid              StorageClass = C.CX_SC_Invalid
+	SC_None                              = C.CX_SC_None
+	SC_Extern                            = C.CX_SC_Extern
+	SC_Static                            = C.CX_SC_Static
+	SC_PrivateExtern                     = C.CX_SC_PrivateExtern
+	SC_OpenCLWorkGroupLocal              = C.CX_SC_OpenCLWorkGroupLocal
+	SC_Auto                              = C.CX_SC_Auto
+	SC_Register                          = C.CX_SC_Register
+)
+
+func (sc StorageClass) Spelling() string {
+	switch sc {
+	case SC_Invalid:
+		return "SC=Invalid"
+	case SC_None:
+		return "SC=None"
+	case SC_Extern:
+		return "SC=Extern"
+	case SC_Static:
+		return "SC=Static"
+	case SC_PrivateExtern:
+		return "SC=PrivateExtern"
+	case SC_OpenCLWorkGroupLocal:
+		return "SC=OpenCLWorkGroupLocal"
+	case SC_Auto:
+		return "SC=Auto"
+	case SC_Register:
+		return "SC=Register"
+	}
+
+	return fmt.Sprintf("StorageClass unkown %d", int(sc))
+}
+
+func (sc StorageClass) String() string {
+	return sc.Spelling()
+}

--- a/clang/string_gen.go
+++ b/clang/string_gen.go
@@ -8,7 +8,7 @@ import "C"
 	A character string.
 
 	The CXString type is used to return strings from the interface when
-	the ownership of that string might different from one call to the next.
+	the ownership of that string might differ from one call to the next.
 	Use clang_getCString() to retrieve the string data and, once finished
 	with the string data, call clang_disposeString() to free the string.
 */

--- a/clang/stringset_gen.go
+++ b/clang/stringset_gen.go
@@ -1,0 +1,27 @@
+package clang
+
+// #include "./clang-c/CXString.h"
+// #include "go-clang.h"
+import "C"
+import (
+	"reflect"
+	"unsafe"
+)
+
+type StringSet struct {
+	c C.CXStringSet
+}
+
+func (ss StringSet) Strings() []cxstring {
+	var s []cxstring
+	gos_s := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	gos_s.Cap = int(ss.c.Count)
+	gos_s.Len = int(ss.c.Count)
+	gos_s.Data = uintptr(unsafe.Pointer(ss.c.Strings))
+
+	return s
+}
+
+func (ss StringSet) Count() uint32 {
+	return uint32(ss.c.Count)
+}

--- a/clang/templateargumentkind_gen.go
+++ b/clang/templateargumentkind_gen.go
@@ -1,0 +1,58 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+import "fmt"
+
+/*
+	Describes the kind of a template argument.
+
+	See the definition of llvm::clang::TemplateArgument::ArgKind for full
+	element descriptions.
+*/
+type TemplateArgumentKind uint32
+
+const (
+	TemplateArgumentKind_Null              TemplateArgumentKind = C.CXTemplateArgumentKind_Null
+	TemplateArgumentKind_Type                                   = C.CXTemplateArgumentKind_Type
+	TemplateArgumentKind_Declaration                            = C.CXTemplateArgumentKind_Declaration
+	TemplateArgumentKind_NullPtr                                = C.CXTemplateArgumentKind_NullPtr
+	TemplateArgumentKind_Integral                               = C.CXTemplateArgumentKind_Integral
+	TemplateArgumentKind_Template                               = C.CXTemplateArgumentKind_Template
+	TemplateArgumentKind_TemplateExpansion                      = C.CXTemplateArgumentKind_TemplateExpansion
+	TemplateArgumentKind_Expression                             = C.CXTemplateArgumentKind_Expression
+	TemplateArgumentKind_Pack                                   = C.CXTemplateArgumentKind_Pack
+	TemplateArgumentKind_Invalid                                = C.CXTemplateArgumentKind_Invalid
+)
+
+func (tak TemplateArgumentKind) Spelling() string {
+	switch tak {
+	case TemplateArgumentKind_Null:
+		return "TemplateArgumentKind=Null"
+	case TemplateArgumentKind_Type:
+		return "TemplateArgumentKind=Type"
+	case TemplateArgumentKind_Declaration:
+		return "TemplateArgumentKind=Declaration"
+	case TemplateArgumentKind_NullPtr:
+		return "TemplateArgumentKind=NullPtr"
+	case TemplateArgumentKind_Integral:
+		return "TemplateArgumentKind=Integral"
+	case TemplateArgumentKind_Template:
+		return "TemplateArgumentKind=Template"
+	case TemplateArgumentKind_TemplateExpansion:
+		return "TemplateArgumentKind=TemplateExpansion"
+	case TemplateArgumentKind_Expression:
+		return "TemplateArgumentKind=Expression"
+	case TemplateArgumentKind_Pack:
+		return "TemplateArgumentKind=Pack"
+	case TemplateArgumentKind_Invalid:
+		return "TemplateArgumentKind=Invalid"
+	}
+
+	return fmt.Sprintf("TemplateArgumentKind unkown %d", int(tak))
+}
+
+func (tak TemplateArgumentKind) String() string {
+	return tak.Spelling()
+}

--- a/clang/translationunit_flags_gen.go
+++ b/clang/translationunit_flags_gen.go
@@ -89,6 +89,18 @@ const (
 	TranslationUnit_SkipFunctionBodies = C.CXTranslationUnit_SkipFunctionBodies
 	// Used to indicate that brief documentation comments should be included into the set of code completions returned from this translation unit.
 	TranslationUnit_IncludeBriefCommentsInCodeCompletion = C.CXTranslationUnit_IncludeBriefCommentsInCodeCompletion
+	// Used to indicate that the precompiled preamble should be created on the first parse. Otherwise it will be created on the first reparse. This trades runtime on the first parse (serializing the preamble takes time) for reduced runtime on the second parse (can now reuse the preamble).
+	TranslationUnit_CreatePreambleOnFirstParse = C.CXTranslationUnit_CreatePreambleOnFirstParse
+	/*
+		Do not stop processing when fatal errors are encountered.
+
+		When fatal errors are encountered while parsing a translation unit,
+		semantic analysis is typically stopped early when compiling code. A common
+		source for fatal errors are unresolvable include files. For the
+		purposes of an IDE, this is undesirable behavior and as much information
+		as possible should be reported. Use this flag to enable this behavior.
+	*/
+	TranslationUnit_KeepGoing = C.CXTranslationUnit_KeepGoing
 )
 
 func (tuf TranslationUnit_Flags) Spelling() string {
@@ -111,6 +123,10 @@ func (tuf TranslationUnit_Flags) Spelling() string {
 		return "TranslationUnit=SkipFunctionBodies"
 	case TranslationUnit_IncludeBriefCommentsInCodeCompletion:
 		return "TranslationUnit=IncludeBriefCommentsInCodeCompletion"
+	case TranslationUnit_CreatePreambleOnFirstParse:
+		return "TranslationUnit=CreatePreambleOnFirstParse"
+	case TranslationUnit_KeepGoing:
+		return "TranslationUnit=KeepGoing"
 	}
 
 	return fmt.Sprintf("TranslationUnit_Flags unkown %d", int(tuf))

--- a/clang/translationunit_gen.go
+++ b/clang/translationunit_gen.go
@@ -47,6 +47,23 @@ func (tu TranslationUnit) LocationForOffset(file File, offset uint32) SourceLoca
 	return SourceLocation{C.clang_getLocationForOffset(tu.c, file.c, C.uint(offset))}
 }
 
+/*
+	Retrieve all ranges that were skipped by the preprocessor.
+
+	The preprocessor will skip lines when they are surrounded by an
+	if/ifdef/ifndef directive whose condition does not evaluate to true.
+*/
+func (tu TranslationUnit) SkippedRanges(file File) *SourceRangeList {
+	o := C.clang_getSkippedRanges(tu.c, file.c)
+
+	var gop_o *SourceRangeList
+	if o != nil {
+		gop_o = &SourceRangeList{*o}
+	}
+
+	return gop_o
+}
+
 // Determine the number of diagnostics produced for the given translation unit.
 func (tu TranslationUnit) NumDiagnostics() uint32 {
 	return uint32(C.clang_getNumDiagnostics(tu.c))
@@ -178,10 +195,11 @@ func (tu TranslationUnit) DefaultReparseOptions() uint32 {
 	The function clang_defaultReparseOptions() produces a default set of
 	options recommended for most uses, based on the translation unit.
 
-	Returns 0 if the sources could be reparsed. A non-zero value will be
+	Returns 0 if the sources could be reparsed. A non-zero error code will be
 	returned if reparsing was impossible, such that the translation unit is
-	invalid. In such cases, the only valid call for \p TU is
-	clang_disposeTranslationUnit(TU).
+	invalid. In such cases, the only valid call for TU is
+	clang_disposeTranslationUnit(TU). The error codes returned by this
+	routine are described by the CXErrorCode enum.
 */
 func (tu TranslationUnit) ReparseTranslationUnit(unsavedFiles []UnsavedFile, options uint32) int32 {
 	gos_unsavedFiles := (*reflect.SliceHeader)(unsafe.Pointer(&unsavedFiles))
@@ -222,6 +240,11 @@ func (tu TranslationUnit) TranslationUnitCursor() Cursor {
 */
 func (tu TranslationUnit) Cursor(sl SourceLocation) Cursor {
 	return Cursor{C.clang_getCursor(tu.c, sl.c)}
+}
+
+// Given a CXFile header file, return the module that contains it, if one exists.
+func (tu TranslationUnit) ModuleForFile(f File) Module {
+	return Module{C.clang_getModuleForFile(tu.c, f.c)}
 }
 
 /*
@@ -353,7 +376,7 @@ func (tu TranslationUnit) DisposeTokens(tokens []Token) {
 	Note that the column should point just after the syntactic construct that
 	initiated code completion, and not in the middle of a lexical token.
 
-	Parameter unsaved_files the Tiles that have not yet been saved to disk
+	Parameter unsaved_files the Files that have not yet been saved to disk
 	but may be required for parsing or code completion, including the
 	contents of those files. The contents and name of these files (as
 	specified by CXUnsavedFile) are copied when necessary, so the

--- a/clang/type_gen.go
+++ b/clang/type_gen.go
@@ -78,6 +78,14 @@ func (t Type) Declaration() Cursor {
 	return Cursor{C.clang_getTypeDeclaration(t.c)}
 }
 
+// Returns the Objective-C type encoding for the specified CXType.
+func (t Type) Encoding() string {
+	o := cxstring{C.clang_Type_getObjCEncoding(t.c)}
+	defer o.Dispose()
+
+	return o.String()
+}
+
 /*
 	Retrieve the calling convention associated with a function type.
 
@@ -88,7 +96,7 @@ func (t Type) FunctionTypeCallingConv() CallingConv {
 }
 
 /*
-	Retrieve the result type associated with a function type.
+	Retrieve the return type associated with a function type.
 
 	If a non-function type is passed in, an invalid type is returned.
 */
@@ -97,7 +105,7 @@ func (t Type) ResultType() Type {
 }
 
 /*
-	Retrieve the number of non-variadic arguments associated with a
+	Retrieve the number of non-variadic parameters associated with a
 	function type.
 
 	If a non-function type is passed in, -1 is returned.
@@ -107,7 +115,7 @@ func (t Type) NumArgTypes() int32 {
 }
 
 /*
-	Retrieve the type of an argument of a function type.
+	Retrieve the type of a parameter of a function type.
 
 	If a non-function type is passed in or the function does not have enough
 	parameters, an invalid type is returned.
@@ -169,6 +177,15 @@ func (t Type) ArraySize() int64 {
 }
 
 /*
+	Retrieve the type named by the qualified-id.
+
+	If a non-elaborated type is passed in, an invalid type is returned.
+*/
+func (t Type) NamedType() Type {
+	return Type{C.clang_Type_getNamedType(t.c)}
+}
+
+/*
 	Return the alignment of a type in bytes as per C++[expr.alignof]
 	standard.
 
@@ -224,6 +241,28 @@ func (t Type) OffsetOf(s string) int64 {
 	defer C.free(unsafe.Pointer(c_s))
 
 	return int64(C.clang_Type_getOffsetOf(t.c, c_s))
+}
+
+/*
+	Returns the number of template arguments for given class template
+	specialization, or -1 if type T is not a class template specialization.
+
+	Variadic argument packs count as only one argument, and can not be inspected
+	further.
+*/
+func (t Type) NumTemplateArguments() int32 {
+	return int32(C.clang_Type_getNumTemplateArguments(t.c))
+}
+
+/*
+	Returns the type template argument of a template class specialization
+	at given index.
+
+	This function only returns template type arguments and does not handle
+	template template arguments or variadic packs.
+*/
+func (t Type) TemplateArgumentAsType(i uint32) Type {
+	return Type{C.clang_Type_getTemplateArgumentAsType(t.c, C.uint(i))}
 }
 
 /*

--- a/clang/typekind_gen.go
+++ b/clang/typekind_gen.go
@@ -8,7 +8,7 @@ import "C"
 type TypeKind uint32
 
 const (
-	// Reprents an invalid type (e.g., where no type is available).
+	// Represents an invalid type (e.g., where no type is available).
 	Type_Invalid TypeKind = C.CXType_Invalid
 	// A type whose specific kind is not exposed via this interface.
 	Type_Unexposed = C.CXType_Unexposed
@@ -69,6 +69,8 @@ const (
 	// A type whose specific kind is not exposed via this interface.
 	Type_ObjCSel = C.CXType_ObjCSel
 	// A type whose specific kind is not exposed via this interface.
+	Type_Float128 = C.CXType_Float128
+	// A type whose specific kind is not exposed via this interface.
 	Type_FirstBuiltin = C.CXType_FirstBuiltin
 	// A type whose specific kind is not exposed via this interface.
 	Type_LastBuiltin = C.CXType_LastBuiltin
@@ -108,6 +110,14 @@ const (
 	Type_DependentSizedArray = C.CXType_DependentSizedArray
 	// A type whose specific kind is not exposed via this interface.
 	Type_MemberPointer = C.CXType_MemberPointer
+	// A type whose specific kind is not exposed via this interface.
+	Type_Auto = C.CXType_Auto
+	/*
+		Represents a type that was referred to using an elaborated type keyword.
+
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*/
+	Type_Elaborated = C.CXType_Elaborated
 )
 
 // Retrieve the spelling of a given CXTypeKind.

--- a/clang/virtualfileoverlay_gen.go
+++ b/clang/virtualfileoverlay_gen.go
@@ -1,0 +1,10 @@
+package clang
+
+// #include "./clang-c/BuildSystem.h"
+// #include "go-clang.h"
+import "C"
+
+// Object encapsulating information about overlaying virtual file/directories over the real file system.
+type VirtualFileOverlay struct {
+	c C.CXVirtualFileOverlay
+}

--- a/clang/visibilitykind_gen.go
+++ b/clang/visibilitykind_gen.go
@@ -1,0 +1,38 @@
+package clang
+
+// #include "./clang-c/Index.h"
+// #include "go-clang.h"
+import "C"
+import "fmt"
+
+type VisibilityKind uint32
+
+const (
+	// This value indicates that no visibility information is available for a provided CXCursor.
+	Visibility_Invalid VisibilityKind = C.CXVisibility_Invalid
+	// Symbol not seen by the linker.
+	Visibility_Hidden = C.CXVisibility_Hidden
+	// Symbol seen by the linker but resolves to a symbol inside this object.
+	Visibility_Protected = C.CXVisibility_Protected
+	// Symbol seen by the linker and acts like a normal symbol.
+	Visibility_Default = C.CXVisibility_Default
+)
+
+func (vk VisibilityKind) Spelling() string {
+	switch vk {
+	case Visibility_Invalid:
+		return "Visibility=Invalid"
+	case Visibility_Hidden:
+		return "Visibility=Hidden"
+	case Visibility_Protected:
+		return "Visibility=Protected"
+	case Visibility_Default:
+		return "Visibility=Default"
+	}
+
+	return fmt.Sprintf("VisibilityKind unkown %d", int(vk))
+}
+
+func (vk VisibilityKind) String() string {
+	return vk.Spelling()
+}


### PR DESCRIPTION
Regenerate from LLVM v3.9 via https://github.com/go-clang/gen/pull/151.

Update: https://github.com/go-clang/gen/issues/141